### PR TITLE
Implement the Ability to Define Clinic Closure Time #261

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask_cors import CORS
 from .config import Config
 from .routes import register_routes
-
+from .models import db     
 
 def create_app():
     """Application factory — creates and configures the Flask app.
@@ -20,5 +20,10 @@ def create_app():
 
     # Register all route blueprints (see app/routes/__init__.py)
     register_routes(app)
+
+    db.init_app(app)   
+    
+    with app.app_context():
+        db.create_all()
 
     return app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,11 @@ class Config:
 
     # Flask debug mode — True in development, False in production
     DEBUG = os.getenv('FLASK_DEBUG', '0') == '1'
+    # DATABASE_URL=postgresql://user:password@localhost/clinic_db
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///clinic.db')
+ 
+    # Disable a feature we don't need
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DB_PATH = os.path.join(BASE_DIR, "database.db")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,6 @@
+from flask_sqlalchemy import SQLAlchemy
+db = SQLAlchemy()
+
 # models/ — define your database models (tables) here.
 # Each model typically maps to one database table.
 #
@@ -13,3 +16,6 @@
 #
 # After creating models, import db and call db.init_app(app) in app/__init__.py,
 # and run db.create_all() inside an app context to create the tables.
+
+# This is the single shared database connection for the whole project.
+# Every model file imports `db` from here: from . import db

--- a/backend/app/models/closure.py
+++ b/backend/app/models/closure.py
@@ -1,0 +1,25 @@
+from . import db
+from datetime import datetime, timezone
+
+
+class Closure(db.Model):
+    __tablename__ = "closures"
+
+    id            = db.Column(db.Integer, primary_key=True)
+    closure_type  = db.Column(db.String(10), nullable=False)  # 'clinic' or 'doctor'
+    doctor_id     = db.Column(db.Integer, nullable=True)       # NULL = clinic-wide
+    start_datetime = db.Column(db.DateTime, nullable=False)
+    end_datetime   = db.Column(db.DateTime, nullable=False)
+    description   = db.Column(db.String(255), nullable=True)   # optional reason
+    created_at    = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self):
+        return {
+            "id":             self.id,
+            "closure_type":   self.closure_type,
+            "doctor_id":      self.doctor_id,
+            "start_datetime": self.start_datetime.isoformat(),
+            "end_datetime":   self.end_datetime.isoformat(),
+            "description":    self.description,
+            "created_at":     self.created_at.isoformat(),
+        }

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,7 +1,7 @@
 from .main import main_bp
+from .closures import closures_bp
 from . import appointmenthistory  # noqa: F401 — registers route on main_bp
 from .appointments import appointments_bp
-
 
 def register_routes(app):
     """Register all Flask blueprints with the app.
@@ -11,3 +11,4 @@ def register_routes(app):
     app.register_blueprint(main_bp, url_prefix='/api')
     app.register_blueprint(appointments_bp, url_prefix='/api/appointments')
     # app.register_blueprint(users_bp, url_prefix='/api/users')
+    app.register_blueprint(closures_bp, url_prefix='/api/closures')

--- a/backend/app/routes/closures.py
+++ b/backend/app/routes/closures.py
@@ -1,0 +1,77 @@
+from flask import Blueprint, request, jsonify
+from datetime import datetime
+from ..services.closure_service import (
+    create_closure,
+    list_closures,
+    get_closure,
+    delete_closure,
+    is_blocked,
+)
+
+closures_bp = Blueprint("closures", __name__)
+
+
+@closures_bp.route("/", methods=["POST"])
+def create():
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Request body must be JSON."}), 400
+
+    try:
+        closure = create_closure(data)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    return jsonify(closure.to_dict()), 201
+
+@closures_bp.route("/", methods=["GET"])
+def list_all():
+    closure_type = request.args.get("type")
+    doctor_id_raw = request.args.get("doctor_id")
+
+    doctor_id = None
+    if doctor_id_raw is not None:
+        try:
+            doctor_id = int(doctor_id_raw)
+        except ValueError:
+            return jsonify({"error": "'doctor_id' must be a number."}), 400
+
+    closures = list_closures(closure_type=closure_type, doctor_id=doctor_id)
+    return jsonify([c.to_dict() for c in closures]), 200
+
+
+@closures_bp.route("/<int:closure_id>", methods=["GET"])
+def retrieve(closure_id):
+    closure = get_closure(closure_id)
+    if closure is None:
+        return jsonify({"error": "Closure not found."}), 404
+    return jsonify(closure.to_dict()), 200
+
+
+@closures_bp.route("/<int:closure_id>", methods=["DELETE"])
+def remove(closure_id):
+    deleted = delete_closure(closure_id)
+    if not deleted:
+        return jsonify({"error": "Closure not found."}), 404
+    return jsonify({"message": "Closure deleted."}), 200
+
+
+@closures_bp.route("/check", methods=["POST"])
+def check():
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Request body must be JSON."}), 400
+
+    try:
+        start_dt  = datetime.fromisoformat(data["start_datetime"])
+        end_dt    = datetime.fromisoformat(data["end_datetime"])
+        doctor_id = int(data["doctor_id"])
+    except (KeyError, TypeError, ValueError):
+        return jsonify({"error": "Required fields: 'start_datetime', 'end_datetime', 'doctor_id'."}), 400
+
+    blocked, reason = is_blocked(start_dt, end_dt, doctor_id)
+
+    response = {"blocked": blocked}
+    if reason:
+        response["reason"] = reason
+    return jsonify(response), 200

--- a/backend/app/services/closure_service.py
+++ b/backend/app/services/closure_service.py
@@ -1,0 +1,110 @@
+from datetime import datetime
+from ..models import db
+from ..models.closure import Closure
+
+
+def _validate(data: dict) -> dict:
+    """Check the incoming data and return a clean version, or raise ValueError."""
+
+    # closure_type must be 'clinic' or 'doctor'
+    closure_type = data.get("closure_type", "").strip().lower()
+    if closure_type not in ("clinic", "doctor"):
+        raise ValueError("'closure_type' must be 'clinic' or 'doctor'.")
+
+    # doctor_id is required when type is 'doctor'
+    doctor_id = data.get("doctor_id")
+    if closure_type == "doctor":
+        if doctor_id is None:
+            raise ValueError("'doctor_id' is required when closure_type is 'doctor'.")
+        doctor_id = int(doctor_id)
+    else:
+        doctor_id = None  
+  
+    try:
+        start_dt = datetime.fromisoformat(data["start_datetime"])
+        end_dt   = datetime.fromisoformat(data["end_datetime"])
+    except (KeyError, TypeError, ValueError):
+        raise ValueError("'start_datetime' and 'end_datetime' must be ISO-8601 strings")
+
+    if end_dt <= start_dt:
+        raise ValueError("'end_datetime' must be after 'start_datetime'.")
+
+    description = (data.get("description") or "").strip() or None
+
+    return {
+        "closure_type":  closure_type,
+        "doctor_id":     doctor_id,
+        "start_datetime": start_dt,
+        "end_datetime":   end_dt,
+        "description":   description,
+    }
+
+
+def create_closure(data: dict) -> Closure:
+    """Validate and save a new closure. Raises ValueError if data is invalid."""
+    clean = _validate(data)
+    closure = Closure(**clean)
+    db.session.add(closure)
+    db.session.commit()
+    return closure
+
+
+def list_closures(closure_type=None, doctor_id=None) -> list:
+    """Return all closures, can be filtered by type and/or doctor."""
+    query = Closure.query
+    if closure_type:
+        query = query.filter_by(closure_type=closure_type.lower())
+    if doctor_id is not None:
+        query = query.filter_by(doctor_id=doctor_id)
+    return query.order_by(Closure.start_datetime).all()
+
+
+def get_closure(closure_id: int) -> Closure | None:
+    """Return a single closure by id, or None if it doesn't exist."""
+    return db.session.get(Closure, closure_id)
+
+
+def delete_closure(closure_id: int) -> bool:
+    """Delete a closure. Returns True if deleted, False if it wasn't found."""
+    closure = db.session.get(Closure, closure_id)
+    if closure is None:
+        return False
+    db.session.delete(closure)
+    db.session.commit()
+    return True
+
+
+def is_blocked(start: datetime, end: datetime, doctor_id: int) -> tuple:
+    """
+    Check if a proposed appointment window overlaps with any closure.
+
+    Returns (True, reason) if blocked, or (False, None) if it's fine.
+
+    An appointment is blocked if:
+      - A clinic-wide closure overlaps the window
+      - A doctor-specific closure for this doctor overlaps the window.
+    """
+    overlapping = Closure.query.filter(
+        Closure.start_datetime < end,   
+        Closure.end_datetime   > start,  
+        db.or_(
+            Closure.closure_type == "clinic",
+            db.and_(
+                Closure.closure_type == "doctor",
+                Closure.doctor_id == doctor_id,
+            ),
+        ),
+    ).first()
+
+    if overlapping is None:
+        return False, None
+
+    if overlapping.closure_type == "clinic":
+        reason = f"The clinic is closed from {overlapping.start_datetime} to {overlapping.end_datetime}."
+    else:
+        reason = f"Doctor {doctor_id} is unavailable from {overlapping.start_datetime} to {overlapping.end_datetime}."
+
+    if overlapping.description:
+        reason += f" Reason: {overlapping.description}"
+
+    return True, reason

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.2
 flask-cors==4.0.0
+flask-sqlalchemy==3.1.1
 python-dotenv==1.0.1

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@
 //   3. Add a <Route path="..." element={<YourPage />} /> inside <Routes>
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+import ClosuresAdmin from './pages/ClosuresAdmin'
 import AppointmentHistory from './pages/AppointmentHistory'
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
     <Routes>
       {/* Each <Route> maps a URL path to a page component */}
       <Route path="/" element={<Home />} />
+      <Route path="/admin/closures" element={<ClosuresAdmin />} />
       <Route path="/appointmenthistory" element={<AppointmentHistory />} />
       {/* Add new routes below as the app grows */}
     </Routes>

--- a/frontend/src/pages/ClosuresAdmin.jsx
+++ b/frontend/src/pages/ClosuresAdmin.jsx
@@ -1,0 +1,240 @@
+// Admin page for managing clinic and doctor closures.
+//
+
+import { useState, useEffect } from 'react'
+import { createClosure, listClosures, deleteClosure } from '../services/closureApi'
+
+// Formats ISO datetime string into something readable"
+function formatDate(iso) {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+const EMPTY_FORM = {
+  closure_type:   'clinic',
+  doctor_id:      '',
+  start_datetime: '',
+  end_datetime:   '',
+  description:    '',
+}
+
+export default function ClosuresAdmin() {
+  const [closures,    setClosures]    = useState([])
+  const [loading,     setLoading]     = useState(true)
+  const [form,        setForm]        = useState(EMPTY_FORM)
+  const [submitting,  setSubmitting]  = useState(false)
+  const [errorMsg,    setErrorMsg]    = useState(null)
+  const [successMsg,  setSuccessMsg]  = useState(null)
+
+  useEffect(() => {
+    listClosures()
+      .then(data => setClosures(data))
+      .catch(() => setErrorMsg('Failed to load closures.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  function handleChange(e) {
+    const { name, value } = e.target
+    setForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setErrorMsg(null)
+    setSuccessMsg(null)
+    setSubmitting(true)
+
+    const payload = {
+      closure_type:   form.closure_type,
+      start_datetime: form.start_datetime,
+      end_datetime:   form.end_datetime,
+      description:    form.description || undefined,
+    }
+
+    if (form.closure_type === 'doctor') {
+      payload.doctor_id = parseInt(form.doctor_id, 10)
+    }
+
+    try {
+      const newClosure = await createClosure(payload)
+      setClosures(prev => [...prev, newClosure])
+      setSuccessMsg('Closure created successfully.')
+      setForm(EMPTY_FORM)
+    } catch (err) {
+      setErrorMsg(err.message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleDelete(id) {
+    if (!window.confirm('Are you sure you want to delete this closure?')) return
+    try {
+      await deleteClosure(id)
+      setClosures(prev => prev.filter(c => c.id !== id))
+    } catch (err) {
+      setErrorMsg('Failed to delete closure: ' + err.message)
+    }
+  }
+
+  return (
+    <div style={styles.page}>
+      <h1 style={styles.heading}>Closure Management</h1>
+      <p style={styles.subtitle}>
+        Define periods when the clinic or a specific doctor is unavailable.
+        Appointments cannot be scheduled during these periods.
+      </p>
+
+      <section style={styles.card}>
+        <h2 style={styles.cardTitle}>New Closure</h2>
+
+        {errorMsg   && <p style={styles.error}>{errorMsg}</p>}
+        {successMsg && <p style={styles.success}>{successMsg}</p>}
+
+        <form onSubmit={handleSubmit} style={styles.form}>
+
+          <label style={styles.label}>
+            Closure Type
+            <select
+              name="closure_type"
+              value={form.closure_type}
+              onChange={handleChange}
+              style={styles.input}
+            >
+              <option value="clinic">Clinic-wide</option>
+              <option value="doctor">Doctor-specific</option>
+            </select>
+          </label>
+
+          {form.closure_type === 'doctor' && (
+            <label style={styles.label}>
+              Doctor ID
+              <input
+                type="number"
+                name="doctor_id"
+                value={form.doctor_id}
+                onChange={handleChange}
+                min="1"
+                required
+                placeholder="e.g. 67"
+                style={styles.input}
+              />
+            </label>
+          )}
+
+          <label style={styles.label}>
+            Start Date &amp; Time
+            <input
+              type="datetime-local"
+              name="start_datetime"
+              value={form.start_datetime}
+              onChange={handleChange}
+              required
+              style={styles.input}
+            />
+          </label>
+
+          <label style={styles.label}>
+            End Date &amp; Time
+            <input
+              type="datetime-local"
+              name="end_datetime"
+              value={form.end_datetime}
+              onChange={handleChange}
+              required
+              style={styles.input}
+            />
+          </label>
+
+          <label style={styles.label}>
+            Reason <span style={styles.optional}>(optional)</span>
+            <input
+              type="text"
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              maxLength={255}
+              placeholder="Insert reason here"
+              style={styles.input}
+            />
+          </label>
+
+          <button type="submit" disabled={submitting} style={styles.btn}>
+            {submitting ? 'Saving…' : 'Create Closure'}
+          </button>
+
+        </form>
+      </section>
+
+      <section style={styles.card}>
+        <h2 style={styles.cardTitle}>Existing Closures</h2>
+
+        {loading ? (
+          <p style={styles.muted}>Loading…</p>
+        ) : closures.length === 0 ? (
+          <p style={styles.muted}>No closures have been added yet.</p>
+        ) : (
+          <table style={styles.table}>
+            <thead>
+              <tr>
+                <th style={styles.th}>Type</th>
+                <th style={styles.th}>Doctor ID</th>
+                <th style={styles.th}>Start</th>
+                <th style={styles.th}>End</th>
+                <th style={styles.th}>Reason</th>
+                <th style={styles.th}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {closures.map(c => (
+                <tr key={c.id} style={styles.tr}>
+                  <td style={styles.td}>
+                    <span style={c.closure_type === 'clinic' ? styles.badgeClinic : styles.badgeDoctor}>
+                      {c.closure_type === 'clinic' ? 'Clinic-wide' : 'Doctor-specific'}
+                    </span>
+                  </td>
+                  <td style={styles.td}>{c.doctor_id ?? '—'}</td>
+                  <td style={styles.td}>{formatDate(c.start_datetime)}</td>
+                  <td style={styles.td}>{formatDate(c.end_datetime)}</td>
+                  <td style={styles.td}>{c.description || '—'}</td>
+                  <td style={styles.td}>
+                    <button onClick={() => handleDelete(c.id)} style={styles.deleteBtn}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = {
+  page:      { maxWidth: 860, margin: '0 auto', padding: '2rem 1rem', fontFamily: 'system-ui, sans-serif', color: '#1a202c' },
+  heading:   { fontSize: '1.75rem', fontWeight: 700, marginBottom: '0.25rem' },
+  subtitle:  { color: '#4a5568', marginBottom: '2rem' },
+  card:      { background: '#fff', border: '1px solid #e2e8f0', borderRadius: 8, padding: '1.5rem', marginBottom: '1.5rem' },
+  cardTitle: { fontSize: '1.1rem', fontWeight: 600, marginTop: 0, marginBottom: '1rem' },
+  form:      { display: 'flex', flexDirection: 'column', gap: '1rem' },
+  label:     { display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem', fontWeight: 500 },
+  input:     { padding: '0.5rem 0.75rem', border: '1px solid #cbd5e0', borderRadius: 6, fontSize: '0.9rem' },
+  optional:  { fontWeight: 400, color: '#718096', marginLeft: 4 },
+  btn:       { padding: '0.6rem 1.25rem', background: '#3182ce', color: '#fff', border: 'none', borderRadius: 6, fontWeight: 600, cursor: 'pointer', alignSelf: 'flex-start' },
+  error:     { color: '#c53030', background: '#fff5f5', border: '1px solid #feb2b2', borderRadius: 6, padding: '0.5rem 0.75rem' },
+  success:   { color: '#276749', background: '#f0fff4', border: '1px solid #9ae6b4', borderRadius: 6, padding: '0.5rem 0.75rem' },
+  table:     { width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' },
+  th:        { textAlign: 'left', padding: '0.5rem 0.75rem', borderBottom: '2px solid #e2e8f0', fontWeight: 600, color: '#4a5568' },
+  tr:        { borderBottom: '1px solid #edf2f7' },
+  td:        { padding: '0.6rem 0.75rem', verticalAlign: 'middle' },
+  muted:     { color: '#718096', fontStyle: 'italic' },
+  badgeClinic:  { display: 'inline-block', padding: '0.15rem 0.5rem', background: '#ebf8ff', color: '#2b6cb0', borderRadius: 12, fontSize: '0.75rem', fontWeight: 600 },
+  badgeDoctor:  { display: 'inline-block', padding: '0.15rem 0.5rem', background: '#faf5ff', color: '#6b46c1', borderRadius: 12, fontSize: '0.75rem', fontWeight: 600 },
+  deleteBtn: { padding: '0.25rem 0.6rem', background: 'transparent', color: '#e53e3e', border: '1px solid #feb2b2', borderRadius: 4, cursor: 'pointer', fontSize: '0.8rem' },
+}

--- a/frontend/src/services/closureApi.js
+++ b/frontend/src/services/closureApi.js
@@ -1,0 +1,43 @@
+const BASE_URL = import.meta.env.VITE_API_BASE || '/api'
+
+async function request(path, options = {}) {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    ...options,
+  })
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data.error || `API error: ${response.status}`)
+  }
+  return data
+}
+
+
+export function createClosure(payload) {
+  return request('/closures/', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+
+export function listClosures(filters = {}) {
+  const params = new URLSearchParams()
+  if (filters.type)      params.set('type', filters.type)
+  if (filters.doctor_id) params.set('doctor_id', filters.doctor_id)
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  return request(`/closures/${qs}`)
+}
+
+
+export function deleteClosure(id) {
+  return request(`/closures/${id}`, { method: 'DELETE' })
+}
+
+
+export function checkClosure(payload) {
+  return request('/closures/check', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}


### PR DESCRIPTION
This closes #261 

Implements the ability for clinic administrators to define periods when appointments cannot be scheduled, including clinic-wide closures and doctor-specific closures.

- Added flask-sqlalchemy as a dependency
- Added database URL configuration
- Initialized the SQLAlchemy db instance
- New Closure database model with fields for closure type, doctor id, date range and reason
- Logic for creating, listing, retrieving, and deleting closures
- is_blocked() can be called by the appointment booking workflow to prevent scheduling during a closure
- Admin page for creating and deleting closures, with a form and a table showing all existing closures (localhost:3000/admin/closures)