### PR TITLE
197 backend admin user management endpoints list update role deactivate

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,5 @@ FLASK_DEBUG=1
 # Use the SERVICE ROLE key on the backend (never expose this to the frontend)
 SUPABASE_URL=https://your-project-id.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+# JWT Secret — find this in Supabase project settings → API → JWT Secret
+SUPABASE_JWT_SECRET=your-jwt-secret-here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,6 +26,9 @@ secret).
     # server ops).
     SUPABASE_URL = os.getenv('SUPABASE_URL')
     SUPABASE_SERVICE_ROLE_KEY = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
+    # JWT secret from Supabase project settings → API → JWT Secret.
+    # Used to verify Supabase-issued access tokens on every protected request.
+    SUPABASE_JWT_SECRET = os.getenv('SUPABASE_JWT_SECRET')
 
     # SQLAlchemy — used by the scheduling module.
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL',

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -1,40 +1,41 @@
-import os
 import jwt
-from flask import jsonify, request, g
+from flask import jsonify, request, g, current_app
 from functools import wraps
-
-SUPABASE_JWT_SECRET = os.getenv(
-    "SUPABASE_JWT_SECRET", "dev-supabase-jwt-secret-change-in-production"
-)
 
 
 def extract_token() -> str | None:
-    """Extracts JWT token from Authorization header
+    """Extracts JWT token from the Authorization header.
 
     Returns:
-        str | None: JWT token
+        str | None: Raw token string, or None if header is missing/malformed.
     """
-
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
         return None
-
     return auth_header.split(" ")[1]
 
 
 def verify_jwt(token: str) -> dict | None:
-    """Verifies JWT token
+    """Verifies a Supabase-issued JWT using the project JWT secret.
+
+    Reads SUPABASE_JWT_SECRET from the Flask app config (set in config.py).
+    Returns the decoded payload dict on success, or None if the token is
+    expired, invalid, or the secret is not configured.
 
     Args:
-        token (str): JWT token to verify
+        token (str): Raw JWT string from the Authorization header.
 
     Returns:
-        dict | None: Payload of a valid JWT
+        dict | None: Decoded JWT payload, or None on any verification failure.
     """
+    secret = current_app.config.get("SUPABASE_JWT_SECRET")
+    if not secret:
+        return None
+
     try:
         payload = jwt.decode(
             token,
-            SUPABASE_JWT_SECRET,
+            secret,
             algorithms=["HS256"],
             options={"verify_aud": False},
         )
@@ -47,7 +48,19 @@ def verify_jwt(token: str) -> dict | None:
 
 
 def requires_auth(f):
-    """Decorator to check if the user is authenticated"""
+    """Decorator that enforces JWT authentication on a route.
+
+    Extracts and verifies the Bearer token from the Authorization header.
+    On success, sets:
+        g.user_id  — the Supabase user UUID (JWT 'sub' claim)
+        g.user     — the full decoded JWT payload dict
+
+    Returns 401 if the token is missing, expired, or invalid.
+
+    Usage:
+        @requires_auth
+        def my_view(): ...
+    """
 
     @wraps(f)
     def wrapper(*args, **kwargs):
@@ -59,10 +72,8 @@ def requires_auth(f):
         if not payload:
             return jsonify({"message": "Invalid or expired token"}), 401
 
-        # Expected to be UUID of the user
-        g.user_id = payload.get("sub")
-        # Expected to be a supabase user
-        g.user = payload
+        g.user_id = payload.get("sub")  # Supabase user UUID
+        g.user = payload                # full JWT payload
 
         return f(*args, **kwargs)
 

--- a/backend/app/repositories/user_roles.py
+++ b/backend/app/repositories/user_roles.py
@@ -1,0 +1,64 @@
+"""
+user_roles repository -- fetch a user's application role from Supabase.
+
+Uses the service role key (bypasses RLS) so the backend can always resolve
+the role regardless of the calling user's permissions.
+"""
+import json
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+
+from flask import current_app
+
+
+def get_role_for_user(user_id: str) -> str | None:
+    """Return the application role name for a given Supabase user UUID.
+
+    Queries the public.user_roles table joined to public.roles.
+    If a user has the 'admin' role it is always returned preferentially;
+    otherwise the first role found is returned.
+
+    Args:
+        user_id (str): Supabase auth UUID (the JWT 'sub' claim).
+
+    Returns:
+        str | None: Role name ('admin', 'doctor', 'patient'), or None if the
+        user has no role or Supabase is unreachable/misconfigured.
+    """
+    base_url = (current_app.config.get("SUPABASE_URL") or "").rstrip("/")
+    service_key = current_app.config.get("SUPABASE_SERVICE_ROLE_KEY")
+
+    if not base_url or not service_key:
+        return None
+
+    query = urlencode({"user_id": f"eq.{user_id}", "select": "roles(name)"})
+    url = f"{base_url}/rest/v1/user_roles?{query}"
+
+    headers = {
+        "apikey": service_key,
+        "Authorization": f"Bearer {service_key}",
+    }
+
+    req = Request(url=url, headers=headers, method="GET")
+    try:
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(data, list) or not data:
+        return None
+
+    role_names = [
+        (row.get("roles") or {}).get("name")
+        for row in data
+        if isinstance(row, dict)
+    ]
+    role_names = [name for name in role_names if name]
+
+    if not role_names:
+        return None
+
+    # Admin takes precedence when a user somehow has multiple roles.
+    return "admin" if "admin" in role_names else role_names[0]

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,22 +1,20 @@
 from .main import main_bp
 from .closures import closures_bp
-from . import appointmenthistory  # noqa: F401 — registers route on
-main_bp
+from . import appointmenthistory  # noqa: F401 -- registers route on main_bp
 from .appointments import appointments_bp
 from .auth import auth_bp
 from .profile import profile_bp
+from .admin import admin_bp
 
 
 def register_routes(app):
     """Register all Flask blueprints with the app.
-    Each blueprint groups a set of related routes (e.g. all appointment
-routes).
+    Each blueprint groups a set of related routes (e.g. all appointment routes).
     Add new blueprints here as the API grows.
     """
     app.register_blueprint(main_bp, url_prefix='/api')
-    app.register_blueprint(appointments_bp,
-url_prefix='/api/appointments')
+    app.register_blueprint(appointments_bp, url_prefix='/api/appointments')
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(profile_bp, url_prefix='/api/profile')
-    # app.register_blueprint(users_bp, url_prefix='/api/users')
+    app.register_blueprint(admin_bp, url_prefix='/api/admin')
     app.register_blueprint(closures_bp, url_prefix='/api/closures')

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1,0 +1,383 @@
+"""
+Admin user management endpoints.
+All routes require an authenticated admin user.
+
+Endpoints:
+    GET    /api/admin/users                      -- list all users (paginated, filterable)
+    PUT    /api/admin/users/<user_id>/role        -- update a user's role
+    PUT    /api/admin/users/<user_id>/deactivate  -- ban a user account
+    DELETE /api/admin/users/<user_id>             -- delete user from auth and DB
+"""
+import json
+from datetime import datetime, timezone
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from flask import Blueprint, current_app, g, jsonify, request
+
+from app.middleware.auth_middleware import requires_auth
+from app.utils.custom_decorators import requires_role
+
+admin_bp = Blueprint("admin", __name__)
+
+VALID_ROLES = {"patient", "doctor", "admin"}
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+def _supabase_request(method, path, *, query=None, json_body=None, prefer=None):
+    """Issue a request to the Supabase REST or Auth Admin API.
+
+    Uses the service role key so it bypasses RLS.
+
+    Args:
+        method (str): HTTP method ('GET', 'POST', 'PUT', 'PATCH', 'DELETE').
+        path (str): Path relative to SUPABASE_URL (e.g. '/rest/v1/users').
+        query (dict | None): Query-string parameters.
+        json_body (dict | None): Request body; sets Content-Type automatically.
+        prefer (str | None): Value for the Supabase 'Prefer' header.
+
+    Returns:
+        tuple[int | None, object | None, str | None]:
+            (http_status, parsed_response, transport_error_message)
+    """
+    base_url = (current_app.config.get("SUPABASE_URL") or "").rstrip("/")
+    service_key = current_app.config.get("SUPABASE_SERVICE_ROLE_KEY")
+
+    if not base_url or not service_key:
+        return None, None, "Supabase is not configured."
+
+    url = f"{base_url}{path}"
+    if query:
+        url = f"{url}?{urlencode(query)}"
+
+    headers = {
+        "apikey": service_key,
+        "Authorization": f"Bearer {service_key}",
+    }
+    if json_body is not None:
+        headers["Content-Type"] = "application/json"
+    if prefer:
+        headers["Prefer"] = prefer
+
+    data = json.dumps(json_body).encode("utf-8") if json_body is not None else None
+    req = Request(url=url, data=data, headers=headers, method=method)
+
+    try:
+        with urlopen(req, timeout=20) as resp:
+            raw = resp.read().decode("utf-8")
+            if not raw:
+                return resp.status, None, None
+            try:
+                return resp.status, json.loads(raw), None
+            except json.JSONDecodeError:
+                return resp.status, raw, None
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8") if exc.fp else ""
+        try:
+            parsed = json.loads(raw) if raw else None
+        except json.JSONDecodeError:
+            parsed = raw or None
+        return exc.code, parsed, None
+    except (URLError, Exception) as exc:
+        return None, None, f"Supabase request failed: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/users
+# ---------------------------------------------------------------------------
+
+@admin_bp.route("/users", methods=["GET"])
+@requires_auth
+@requires_role({"admin"})
+def list_users():
+    """Return a paginated list of all users with their role and status.
+
+    Query params:
+        page     (int, default 1)   -- page number
+        per_page (int, default 20, max 100)
+        role     (str, optional)    -- filter by role: patient | doctor | admin
+        status   (str, optional)    -- filter by status: active | inactive
+
+    Returns 200 with:
+        {
+          "users": [...],
+          "page": 1,
+          "per_page": 20,
+          "total": N
+        }
+    """
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 20, type=int), 100)
+    role_filter = request.args.get("role")
+    status_filter = request.args.get("status")
+
+    if role_filter and role_filter not in VALID_ROLES:
+        return jsonify({"error": f'Invalid role filter. Must be one of: {", ".join(sorted(VALID_ROLES))}'}), 400
+    if status_filter and status_filter not in ("active", "inactive"):
+        return jsonify({"error": 'Invalid status filter. Must be "active" or "inactive".'}), 400
+
+    # Build user_id -> role_name map from user_roles + roles
+    role_status, role_data, err = _supabase_request(
+        "GET",
+        "/rest/v1/user_roles",
+        query={"select": "user_id,roles(name)"},
+    )
+    if err or role_status != 200:
+        return jsonify({"error": "Failed to fetch user roles."}), 500
+
+    role_map: dict[str, str] = {}
+    for row in (role_data or []):
+        uid = row.get("user_id")
+        role_name = (row.get("roles") or {}).get("name")
+        if uid and role_name:
+            # Admin takes precedence if a user somehow has multiple roles.
+            if uid not in role_map or role_name == "admin":
+                role_map[uid] = role_name
+
+    # Fetch users from Supabase Auth Admin API (paginated)
+    auth_status, auth_data, err = _supabase_request(
+        "GET",
+        "/auth/v1/admin/users",
+        query={"page": page, "per_page": per_page},
+    )
+    if err or auth_status != 200:
+        return jsonify({"error": "Failed to fetch users from auth."}), 500
+
+    raw_users = auth_data.get("users", []) if isinstance(auth_data, dict) else (auth_data or [])
+
+    now = datetime.now(timezone.utc)
+    result = []
+
+    for user in raw_users:
+        uid = user.get("id")
+        role = role_map.get(uid)
+
+        # Derive status from banned_until field set by deactivate endpoint.
+        banned_until_str = user.get("banned_until")
+        is_banned = False
+        if banned_until_str:
+            try:
+                banned_dt = datetime.fromisoformat(banned_until_str.replace("Z", "+00:00"))
+                is_banned = banned_dt > now
+            except (ValueError, TypeError):
+                pass
+        status = "inactive" if is_banned else "active"
+
+        if role_filter and role != role_filter:
+            continue
+        if status_filter and status != status_filter:
+            continue
+
+        result.append({
+            "user_id": uid,
+            "email": user.get("email"),
+            "role": role,
+            "status": status,
+            "created_at": user.get("created_at"),
+            "last_sign_in_at": user.get("last_sign_in_at"),
+        })
+
+    return jsonify({
+        "users": result,
+        "page": page,
+        "per_page": per_page,
+        "total": len(result),
+    }), 200
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/users/<user_id>/role
+# ---------------------------------------------------------------------------
+
+@admin_bp.route("/users/<user_id>/role", methods=["PUT"])
+@requires_auth
+@requires_role({"admin"})
+def update_user_role(user_id):
+    """Update a user's application role.
+
+    Request body (JSON):
+        { "role": "patient" | "doctor" | "admin" }
+
+    Replaces the user's existing role entirely.
+    Records the acting admin as granted_by.
+
+    Returns 200 with { user_id, role, message }.
+    """
+    data = request.get_json(silent=True)
+    if not data or "role" not in data:
+        return jsonify({"error": 'Request body must include "role".'}), 400
+
+    new_role = data["role"]
+    if new_role not in VALID_ROLES:
+        return jsonify({"error": f'Invalid role. Must be one of: {", ".join(sorted(VALID_ROLES))}'}), 400
+
+    # Resolve role name to role_id from the roles table.
+    role_status, role_data, err = _supabase_request(
+        "GET",
+        "/rest/v1/roles",
+        query={"name": f"eq.{new_role}", "select": "id"},
+    )
+    if err or role_status != 200 or not role_data:
+        return jsonify({"error": f'Role "{new_role}" not found in the roles table.'}), 400
+
+    role_id = role_data[0]["id"]
+
+    # Remove all existing roles for this user, then insert the new one.
+    # The composite PK (user_id, role_id) allows multiple roles per user,
+    # but the system treats each user as having a single active role.
+    del_status, _, err = _supabase_request(
+        "DELETE",
+        "/rest/v1/user_roles",
+        query={"user_id": f"eq.{user_id}"},
+        prefer="return=minimal",
+    )
+    if err or del_status not in (200, 204):
+        return jsonify({"error": "Failed to remove existing role."}), 500
+
+    ins_status, _, err = _supabase_request(
+        "POST",
+        "/rest/v1/user_roles",
+        json_body={"user_id": user_id, "role_id": role_id, "granted_by": g.user_id},
+        prefer="return=minimal",
+    )
+    if err or ins_status not in (200, 201):
+        return jsonify({"error": "Failed to assign new role."}), 500
+
+    return jsonify({"message": f'Role updated to "{new_role}".', "user_id": user_id, "role": new_role}), 200
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/users/<user_id>/deactivate
+# ---------------------------------------------------------------------------
+
+@admin_bp.route("/users/<user_id>/deactivate", methods=["PUT"])
+@requires_auth
+@requires_role({"admin"})
+def deactivate_user(user_id):
+    """Ban a user account so they cannot log in.
+
+    Uses Supabase's ban_duration mechanism. A duration of '876600h' (~100 years)
+    is used as an indefinite ban. The user remains in the database and their
+    data is preserved; only authentication is blocked.
+
+    Admins cannot deactivate their own account.
+
+    Returns 200 with { user_id, message }.
+    """
+    if user_id == g.user_id:
+        return jsonify({"error": "Admins cannot deactivate their own account."}), 400
+
+    status, _, err = _supabase_request(
+        "PUT",
+        f"/auth/v1/admin/users/{user_id}",
+        json_body={"ban_duration": "876600h"},
+    )
+    if err or status not in (200, 204):
+        return jsonify({"error": "Failed to deactivate user."}), 500
+
+    return jsonify({"message": "User deactivated successfully.", "user_id": user_id}), 200
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/users/<user_id>
+# ---------------------------------------------------------------------------
+
+@admin_bp.route("/users/<user_id>", methods=["DELETE"])
+@requires_auth
+@requires_role({"admin"})
+def delete_user(user_id):
+    """Permanently delete a user from both the application DB and Supabase Auth.
+
+    Deletes records in dependency order to satisfy FK constraints:
+      1. Doctor-linked rows (appointments, time_slots, availability_rules, waitlist)
+         resolved via doctors.user_id -> doctors.id
+      2. Patient-linked rows (appointments, waitlist by patient_id)
+      3. Settings tables (patient_settings, provider_settings, profile_settings)
+      4. Role table (user_roles)
+      5. Profile-linked tables (patients, providers, profiles)
+      6. Auth user (Supabase Auth Admin API)
+
+    Admins cannot delete their own account.
+
+    Returns 200 with { user_id, message }.
+    """
+    if user_id == g.user_id:
+        return jsonify({"error": "Admins cannot delete their own account."}), 400
+
+    def _delete(table, col, value):
+        """Run a DELETE and return (ok, error_response)."""
+        s, _, e = _supabase_request(
+            "DELETE",
+            f"/rest/v1/{table}",
+            query={col: f"eq.{value}"},
+            prefer="return=minimal",
+        )
+        if e or s not in (200, 204, 404):
+            return False, jsonify({"error": f"Failed to delete from {table}."}), 500
+        return True, None
+
+    # Step 1: Resolve doctor record (doctors table uses its own UUID, not auth user_id)
+    doc_status, doc_data, _ = _supabase_request(
+        "GET",
+        "/rest/v1/doctors",
+        query={"user_id": f"eq.{user_id}", "select": "id"},
+    )
+    if doc_status == 200 and isinstance(doc_data, list) and doc_data:
+        doctor_id = doc_data[0].get("id")
+        if doctor_id:
+            for table, col in [
+                ("appointments", "doctor_id"),
+                ("time_slots", "doctor_id"),
+                ("availability_rules", "doctor_id"),
+                ("waitlist", "doctor_id"),
+            ]:
+                ok, err_resp = _delete(table, col, doctor_id)
+                if not ok:
+                    return err_resp
+            ok, err_resp = _delete("doctors", "id", doctor_id)
+            if not ok:
+                return err_resp
+
+    # Step 2: Patient-linked rows (patient_id == auth user UUID)
+    for table, col in [
+        ("appointments", "patient_id"),
+        ("waitlist", "patient_id"),
+    ]:
+        ok, err_resp = _delete(table, col, user_id)
+        if not ok:
+            return err_resp
+
+    # Step 3: Settings and role tables
+    for table, col in [
+        ("patient_settings", "user_id"),
+        ("provider_settings", "user_id"),
+        ("user_roles", "user_id"),
+        ("profile_settings", "user_id"),
+    ]:
+        ok, err_resp = _delete(table, col, user_id)
+        if not ok:
+            return err_resp
+
+    # Step 4: Profile-linked tables (patients, providers reference profiles.user_id)
+    for table, col in [
+        ("patients", "user_id"),
+        ("providers", "user_id"),
+        ("profiles", "user_id"),
+    ]:
+        ok, err_resp = _delete(table, col, user_id)
+        if not ok:
+            return err_resp
+
+    # Step 5: Delete the auth user
+    auth_status, _, err = _supabase_request(
+        "DELETE",
+        f"/auth/v1/admin/users/{user_id}",
+    )
+    if err or auth_status not in (200, 204):
+        return jsonify({"error": "Failed to delete user from auth."}), 500
+
+    return jsonify({"message": "User deleted successfully.", "user_id": user_id}), 200

--- a/backend/app/routes/appointmenthistory.py
+++ b/backend/app/routes/appointmenthistory.py
@@ -1,8 +1,17 @@
-from flask import jsonify
+from flask import jsonify, g
 from app.config import get_db_connection
+from app.middleware.auth_middleware import requires_auth
 from .main import main_bp
+
+
 @main_bp.route('/appointment-history/<int:user_id>', methods=['GET'])
+@requires_auth
 def get_appointment_history(user_id):
+    # Users can only access their own history; admins are handled at the
+    # admin endpoints layer.
+    if g.user_id != str(user_id):
+        return jsonify({'error': 'Forbidden: you can only view your own appointment history.'}), 403
+
     conn = get_db_connection()
     appointments = conn.execute(
         '''

--- a/backend/app/routes/appointments.py
+++ b/backend/app/routes/appointments.py
@@ -3,6 +3,7 @@ Appointment form submission API (skeleton).
 POST /api/appointments/submit — accepts form data; persistence to Supabase is TODO.
 """
 from flask import Blueprint, request, jsonify
+from app.middleware.auth_middleware import requires_auth
 
 appointments_bp = Blueprint('appointments', __name__)
 
@@ -10,6 +11,7 @@ REQUIRED_FIELDS = ('name', 'surname', 'symptoms_and_or_allergies', 'medications'
 
 
 @appointments_bp.route('/submit', methods=['POST'])
+@requires_auth
 def submit_appointment():
     """
     Submit appointment form data.

--- a/backend/app/routes/closures.py
+++ b/backend/app/routes/closures.py
@@ -7,11 +7,15 @@ from ..services.closure_service import (
     delete_closure,
     is_blocked,
 )
+from app.middleware.auth_middleware import requires_auth
+from app.utils.custom_decorators import requires_role
 
 closures_bp = Blueprint("closures", __name__)
 
 
 @closures_bp.route("/", methods=["POST"])
+@requires_auth
+@requires_role({"admin", "doctor"})
 def create():
     data = request.get_json(silent=True)
     if not data:
@@ -24,7 +28,9 @@ def create():
 
     return jsonify(closure.to_dict()), 201
 
+
 @closures_bp.route("/", methods=["GET"])
+@requires_auth
 def list_all():
     closure_type = request.args.get("type")
     doctor_id_raw = request.args.get("doctor_id")
@@ -41,6 +47,7 @@ def list_all():
 
 
 @closures_bp.route("/<int:closure_id>", methods=["GET"])
+@requires_auth
 def retrieve(closure_id):
     closure = get_closure(closure_id)
     if closure is None:
@@ -49,6 +56,8 @@ def retrieve(closure_id):
 
 
 @closures_bp.route("/<int:closure_id>", methods=["DELETE"])
+@requires_auth
+@requires_role({"admin", "doctor"})
 def remove(closure_id):
     deleted = delete_closure(closure_id)
     if not deleted:
@@ -57,6 +66,7 @@ def remove(closure_id):
 
 
 @closures_bp.route("/check", methods=["POST"])
+@requires_auth
 def check():
     data = request.get_json(silent=True)
     if not data:

--- a/backend/app/routes/main.py
+++ b/backend/app/routes/main.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, request
 
 from app.repositories.availability import get_availability_for_doctor_date
 from app.services.scheduling import generate_available_slots
+from app.middleware.auth_middleware import requires_auth
 
 # A Blueprint groups related routes together.
 # 'main' is the name used internally by Flask to identify this blueprint.
@@ -21,6 +22,7 @@ def health_check():
 
 
 @main_bp.route('/doctors/<doctor_id>/available-slots', methods=['GET'])
+@requires_auth
 def get_doctor_available_slots(doctor_id: str):
     """Return available appointment time slots for a doctor on a given date.
 

--- a/backend/app/services/registration.py
+++ b/backend/app/services/registration.py
@@ -86,6 +86,15 @@ def sync_user_after_registration(user_id: str, data: dict) -> dict:
             inserted.append(('patients', user_id))
             logger.info('patients row created for user %s', user_id)
 
+            patient_settings_row = {
+                'user_id':              user_id,
+                'notify_laboratory':    True,
+                'notify_prescription':  True,
+            }
+            supabase.table('patient_settings').insert(patient_settings_row).execute()
+            inserted.append(('patient_settings', user_id))
+            logger.info('patient_settings row created for user %s', user_id)
+
         elif role == 'doctor':
             provider_row = {
                 'user_id':          user_id,
@@ -98,6 +107,16 @@ def sync_user_after_registration(user_id: str, data: dict) -> dict:
             supabase.table('providers').insert(provider_row).execute()
             inserted.append(('providers', user_id))
             logger.info('providers row created for user %s', user_id)
+
+            provider_settings_row = {
+                'user_id':                      user_id,
+                'auto_accept_appointments':     False,
+                'appointment_buffer_minutes':   0,
+                'default_appointment_duration': 30,
+            }
+            supabase.table('provider_settings').insert(provider_settings_row).execute()
+            inserted.append(('provider_settings', user_id))
+            logger.info('provider_settings row created for user %s', user_id)
 
         # ── Step 4: user_roles ────────────────────────────────────────────
         role_id = _get_role_id(supabase, role)

--- a/backend/app/utils/custom_decorators.py
+++ b/backend/app/utils/custom_decorators.py
@@ -1,56 +1,44 @@
 from functools import wraps
-import sqlite3
 from flask import g, jsonify
+from app.repositories.user_roles import get_role_for_user
 
 
-def get_user_roles(user_id: int, db: sqlite3.Connection) -> set[str]:
-    """Returns the roles of a user
+def requires_role(required_roles: set[str]):
+    """Decorator that restricts a route to users with one of the required roles.
 
-    Args:
-        user_id (int): user id
-        db (sqlite3.Connection): database connection
-
-    Returns:
-        set[str]: set of roles
-    """
-    cursor = db.cursor()
-    query = """
-            SELECT roles.name FROM user_roles
-            JOIN roles ON user_roles.role_id = roles.id
-            WHERE user_roles.user_id = ?
-            """
-    cursor.execute(query, (user_id,))
-    rows = cursor.fetchall()
-
-    role_names = {row[0] for row in rows}
-    return role_names
-
-
-def requires_role(required_roles: set[str], db: sqlite3.Connection):
-    """Decorator to check if the user has the required roles
+    Must be applied after @requires_auth, which sets g.user_id.
+    Fetches the user's role from Supabase and returns 403 if it is not in
+    the required set.
 
     Example usage:
-    @requires_role({"admin"}, database_connection)
-    @requires_role({"admin", "doctor", ...}, database_connection)
+        @requires_auth
+        @requires_role({"admin"})
+        def admin_only_view(): ...
 
-    This will check if the user has at least one of the required roles.
+        @requires_auth
+        @requires_role({"admin", "doctor"})
+        def admin_or_doctor_view(): ...
 
     Args:
-        required_roles (set[str]): set of required roles
-        db (sqlite3.Connection): database connection
+        required_roles (set[str]): Set of role names that are allowed access.
+
+    Returns 401 if g.user_id is not set (requires_auth not applied).
+    Returns 403 if the user's role is not in required_roles.
+    Sets g.user_role to the resolved role string on success.
     """
 
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            user_id = g.user_id
+            user_id = getattr(g, "user_id", None)
             if not user_id:
                 return jsonify({"message": "Not authenticated"}), 401
 
-            user_roles = get_user_roles(user_id, db)
-            if not (user_roles & required_roles):
+            role = get_role_for_user(user_id)
+            if role not in required_roles:
                 return jsonify({"message": "Forbidden"}), 403
 
+            g.user_role = role
             return f(*args, **kwargs)
 
         return wrapper

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ flask-cors==4.0.0
 python-dotenv==1.0.1
 supabase==2.10.0
 flask-sqlalchemy==3.1.1
+PyJWT>=2.8.0

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -87,7 +87,7 @@ function Register() {
 
     setLoading(true)
     try {
-      const result = await registerUser(fields.email, fields.password)
+      const result = await registerUser(fields.email, fields.password, fields.firstName, fields.lastName)
 
       if (result.emailConfirmationRequired) {
         setEmailConfirmationRequired(true)

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -51,7 +51,7 @@ function formatAuthError(message) {
  * Returns: { user, session, emailConfirmationRequired }
  * Throws:  Error with a user-friendly message on failure.
  */
-export async function registerUser(email, password) {
+export async function registerUser(email, password, firstName, lastName) {
   const { data, error } = await supabase.auth.signUp({ email, password })
 
   if (error) {
@@ -62,7 +62,13 @@ export async function registerUser(email, password) {
 
   if (user) {
     try {
-      await syncRegistration({ supabase_uid: user.id, email: user.email })
+      await syncRegistration({
+        user_id:    user.id,
+        first_name: firstName,
+        last_name:  lastName,
+        username:   email.split('@')[0],
+        role:       'patient',
+      })
     } catch (syncError) {
       console.error('DB sync failed after registration:', syncError.message)
     }


### PR DESCRIPTION
Summary
- Fixed JWT verification middleware (secret loaded at import time, silent fallback to dummy string)
- Rewrote requires_role decorator to query Supabase instead of local SQLite
- Applied @requires_auth to all previously unprotected routes
- Added admin blueprint: list users, update role, deactivate, delete