### PR TITLE
Add mutation testing writeup to section 3.2 (Milestone 2)

### DIFF
--- a/docs/Milestone_1/sections/section3/subsections/3.2.adoc
+++ b/docs/Milestone_1/sections/section3/subsections/3.2.adoc
@@ -116,3 +116,142 @@ Scenarios analyzed include:
 Walkthroughs identified logical gaps and ambiguous constraints, which were resolved through documentation refinement.
 
 This process satisfies the rubric requirement for structured inspection and review.
+
+
+==== *Mutation Testing — Patient Experience Team* _(Milestone 2)_
+
+===== Overview
+
+Mutation testing was performed on `backend/src/booking.py` using *mutmut 2.5.1*.
+The module consolidates the core booking logic for the Patient Experience team:
+appointment-form validation, time-range arithmetic (slot generation, blocked-period
+subtraction), conflict detection, and the top-level `book_appointment` entry point.
+
+Command used:
+
+[source,bash]
+----
+mutmut run \
+  --paths-to-mutate src/booking.py \
+  --tests-dir tests \
+  --runner "python3 -m pytest"
+----
+
+===== Mutation Score — Before Adding New Tests
+
+|===
+| Metric | Count
+
+| Total mutants generated | 78
+| Killed (🎉) | 64
+| Timed out (⏰) | 1
+| Survived (🙁) | 13
+| *Mutation score* | *83.1%* (64 ÷ 77)
+|===
+
+The 13 surviving mutants clustered around five areas:
+
+. Frozen-dataclass flag on `TimeRange` and `DailyAvailability` (no immutability test)
+. Off-by-one in `slot_minutes` guards (`<= 0` → `<= 1`)
+. Corrupted `ValueError` message strings (test matched the mutant via substring search)
+. Boundary conditions in `_subtract_segment` no-overlap check
+. `normalized["start"]` set to `None` instead of `proposed_start.isoformat()`
+
+===== Surviving Mutant Analysis
+
+The table below documents each surviving mutant, the reason it survived, and the action taken.
+
+[cols="1,3,3,2", options="header"]
+|===
+| Mutant ID | Mutation | Why Tests Missed It | New Test Added?
+
+| 17
+| `@dataclass(frozen=True)` → `frozen=False` on `TimeRange`
+| No test verified that `TimeRange` is immutable / hashable
+| Yes — `test_time_range_is_hashable`, `test_time_range_is_immutable`
+
+| 28
+| `slot_minutes \<= 0` → `slot_minutes \<= 1` in `TimeRange.split`
+| No test passed `slot_minutes=1` (a valid value)
+| Yes — `test_slot_minutes_1_is_valid`
+
+| 29
+| `raise ValueError("slot_minutes must be positive")` → corrupted message in `split`
+| `pytest.raises(match=...)` used `re.search`; the pattern matched as a substring of the corrupted string
+| Yes — anchored pattern `^slot_minutes must be positive$`
+
+| 45
+| `blk_end \<= seg_start` → `blk_end < seg_start` (no-overlap check)
+| *Equivalent mutant* — when `blk_end == seg_start`, the pieces calculation still reconstructs the original segment; observable behavior is identical
+| No (unkillable)
+
+| 46
+| `blk_start >= seg_end` → `blk_start > seg_end` (no-overlap check)
+| *Equivalent mutant* — same reasoning as #45
+| No (unkillable)
+
+| 47
+| `or` → `and` in `if blk_end \<= seg_start or blk_start >= seg_end`
+| *Equivalent mutant* — the `and` condition is never True for valid ranges; individual conditions each produce the same pieces result
+| No (unkillable)
+
+| 49
+| `blk_start > seg_start` → `blk_start >= seg_start` (left-piece guard)
+| No test where block starts exactly at segment start
+| Yes — `test_block_starts_at_segment_start_no_left_piece`
+
+| 50
+| `blk_end < seg_end` → `blk_end \<= seg_end` (right-piece guard)
+| No test where block ends exactly at segment end
+| Yes — `test_block_ends_at_segment_end_no_right_piece`
+
+| 51
+| `@dataclass(frozen=True)` → `frozen=False` on `DailyAvailability`
+| No test verified immutability of `DailyAvailability`
+| Yes — `test_daily_availability_is_immutable`
+
+| 53
+| `availability.slot_minutes \<= 0` → `< 0` in `generate_available_slots`
+| With `slot_minutes=0`, the mutant still raised `ValueError` (from `split`), so `pytest.raises(ValueError)` passed under both versions
+| Yes — test with fully-blocked working hours so no segment reaches `split`; mutant returns `[]` instead of raising
+
+| 54
+| `availability.slot_minutes \<= 0` → `\<= 1` in `generate_available_slots`
+| No test used `slot_minutes=1` against `generate_available_slots`
+| Yes — `test_slot_minutes_1_is_valid_for_generate`
+
+| 55
+| `raise ValueError(...)` → corrupted message in `generate_available_slots`
+| Same substring-match issue as mutant 29
+| Yes — anchored `^...$` regex pattern
+
+| 75
+| `normalized["start"] = proposed_start.isoformat()` → `None`
+| Tests only checked that `"start"` was present, not its value
+| Yes — `test_start_value_matches_proposed_start`, `test_start_is_not_none`
+|===
+
+===== Mutation Score — After Adding New Tests
+
+|===
+| Metric | Count
+
+| Total mutants | 78
+| Killed (🎉) | 74
+| Timed out (⏰) | 1
+| Survived (🙁) | 3
+| *Mutation score* | *96.2%* (75 ÷ 78, counting timeout as killed)
+|===
+
+The 3 remaining survivors (#45, #46, #47) are confirmed *equivalent mutants*: their
+altered logic produces identical output in all reachable scenarios because the
+_subtract_segment pieces calculation naturally reconstructs the original segment
+when the block is exactly adjacent to the segment boundary.
+
+===== Summary
+
+- Initial mutation score: *83.1%*
+- Final mutation score: *96.2%*
+- Mutants killed by new tests: *10* (of the original 13 survivors)
+- Equivalent mutants identified and documented: *3*
+- Total new tests added: 15 (in `backend/tests/test_booking.py`)


### PR DESCRIPTION
                                                                                                                                                                       
  Title: Add Mutation Testing Writeup to Section 3.2 (Milestone 2)                                                                                                            
                                                                                                                                                                              
  Description:                                                                                                                                                                
                                                                                                                                                                              
  Adds the mutation testing writeup for the Patient Experience team to docs/Milestone_1/sections/section3/subsections/3.2.adoc as required by Milestone 2.                    
                                                                                                                                                                              
  What's included:                                                                                                                                                            
  - Full mutation testing report for backend/src/booking.py using mutmut
  - Mutation score before adding new tests: 83.1%                                                                                                                             
  - Mutation score after adding new tests: 96.2%            
  - Table documenting all 13 surviving mutants: what the mutation was, why tests missed it, and whether a new test was added to kill it                                       
  - 3 confirmed equivalent mutants identified and explained                                                                                                                   
  - Summary of 10 mutants killed by the 15 new tests added                                                                                                                    
                                                                                                                                                                              
  Related branch: feature/mutation-testing-booking-logic (contains the actual booking.py module and test file)           