### PR TITLE
Add defect report for late-cancellation slot availability bug (#101)

### DIFF
--- a/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
+++ b/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
@@ -11,7 +11,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 
 ===== Severity
 
-*High* — The defect directly reduces appointment availability for patients during peak demand windows, blocking bookings that would otherwise succeed. Clinics operating with limited open slots are particularly affected.
+*High* - The defect directly reduces appointment availability for patients during peak demand windows, blocking bookings that would otherwise succeed. Clinics operating with limited open slots are particularly affected.
 
 ===== Status
 
@@ -27,7 +27,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 ===== Software Configuration
 
 * *Application*: Simple Medical Appointments web application (`base-code` branch)
-* *Frontend*: React — any modern browser (Chrome, Firefox, Edge, Safari)
+* *Frontend*: React - any modern browser (Chrome, Firefox, Edge, Safari)
 * *Backend*: Node.js with Supabase as the database/auth provider
 * *OS*: No specific operating system dependency
 
@@ -37,7 +37,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 . Navigate to the *Upcoming Appointments* section.
 . Select a confirmed appointment whose start time is less than 1 hour from now (e.g., appointment at 10:00, current time is 09:15).
 . Click *Cancel Appointment* and confirm the cancellation dialog.
-. Observe the appointment status — it should change to *Cancelled*.
+. Observe the appointment status - it should change to *Cancelled*.
 . Log out and log in as a different patient account (or use an incognito session).
 . Navigate to *Book an Appointment* and search for the same doctor and time slot that was just cancelled.
 . Observe whether the previously cancelled slot appears as available.
@@ -60,7 +60,7 @@ This defect has real-world consequences for both patients and clinics:
 
 ===== Proposed Solution
 
-The root cause is likely in the cancellation handler — when a late cancellation is processed, the slot availability flag is not being updated in the database. The fix should ensure that, upon any successful cancellation (regardless of timing), the corresponding time slot record is set back to *Available*.
+The root cause is likely in the cancellation handler. When a late cancellation is processed, the slot availability flag is not being updated in the database. The fix should ensure that, upon any successful cancellation (regardless of timing), the corresponding time slot record is set back to *Available*.
 
 Specifically:
 
@@ -71,3 +71,11 @@ Specifically:
   .. Cancels the appointment.
   .. Asserts that the slot is available again.
 . Verify that any cron jobs or background processes responsible for slot management are not overriding the release with stale cached state.
+
+===== Priority
+
+*Medium* - While the severity is High, this defect occurs only under a specific time constraint (cancellation within 1 hour of the appointment). It does not affect the majority of cancellations and does not block core booking functionality. It should be addressed before release but is not a blocker for ongoing development.
+
+===== Root Cause
+
+*To be determined* - Suspected coding error in the cancellation handler, where the slot availability update is either skipped or conditionally blocked when the cancellation occurs within the 1-hour window. Possibly an unintended guard clause tied to the late-cancellation policy logic.

--- a/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
+++ b/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
@@ -1,1 +1,64 @@
 === *Defect Reporting and Management*
+
+==== Late-Cancellation Time Slot Not Released Back to Availability
+:author: Diego Perez
+
+===== Title
+
+Time slot remains unavailable after patient cancels appointment within 1 hour of scheduled start time.
+
+===== Severity
+
+*High* — The defect directly reduces appointment availability for patients during peak demand windows, blocking bookings that would otherwise succeed. Clinics operating with limited open slots are particularly affected.
+
+===== Status
+
+*Open*
+
+===== Initial Configuration
+
+* A registered patient account with at least one upcoming confirmed appointment.
+* The appointment is scheduled within the next 60 minutes (i.e., less than 1 hour away).
+* The time slot was previously marked as *Unavailable* upon booking confirmation.
+* The system is running and the scheduling/cancellation API is accessible.
+
+===== Steps to Reproduce
+
+. Log in as a registered patient.
+. Navigate to the *Upcoming Appointments* section.
+. Select a confirmed appointment whose start time is less than 1 hour from now (e.g., appointment at 10:00, current time is 09:15).
+. Click *Cancel Appointment* and confirm the cancellation dialog.
+. Observe the appointment status — it should change to *Cancelled*.
+. Log out and log in as a different patient account (or use an incognito session).
+. Navigate to *Book an Appointment* and search for the same doctor and time slot that was just cancelled.
+. Observe whether the previously cancelled slot appears as available.
+
+===== Expected Behavior
+
+After the patient cancels the appointment, regardless of how close the cancellation occurs to the scheduled start time, the time slot should be released and marked as *Available*. Any other patient should be able to book that slot immediately after cancellation.
+
+===== Actual Behavior
+
+The time slot remains marked as *Unavailable* after the cancellation. Other patients cannot book the released slot. The slot does not reappear in the booking calendar, effectively leaving it blocked for the remainder of the day even though no appointment is attached to it.
+
+===== Impact
+
+This defect has real-world consequences for both patients and clinics:
+
+* *Patients*: Patients seeking last-minute appointments cannot access slots that have technically been freed. This is especially critical for urgent or same-day medical needs where availability is scarce.
+* *Clinics*: Doctors end up with empty appointment slots that the system prevents from being filled. This reduces throughput, wastes clinical capacity, and can lead to revenue loss for the practice.
+* *Trust*: Patients who encounter "no availability" when they know cancellations occur may lose confidence in the platform's accuracy, undermining adoption.
+
+===== Proposed Solution
+
+The root cause is likely in the cancellation handler — when a late cancellation is processed, the slot availability flag is not being updated in the database. The fix should ensure that, upon any successful cancellation (regardless of timing), the corresponding time slot record is set back to *Available*.
+
+Specifically:
+
+. In the cancellation API endpoint (or service layer), after updating the appointment status to `CANCELLED`, add or verify a call to update the time slot's availability field to `true` (or equivalent in the schema).
+. Add an integration test that:
+  .. Books a slot.
+  .. Advances the simulated clock to within 59 minutes of the appointment.
+  .. Cancels the appointment.
+  .. Asserts that the slot is available again.
+. Verify that any cron jobs or background processes responsible for slot management are not overriding the release with stale cached state.

--- a/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
+++ b/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
@@ -22,6 +22,13 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 * The time slot was previously marked as *Unavailable* upon booking confirmation.
 * The system is running and the scheduling/cancellation API is accessible.
 
+===== Software Configuration
+
+* *Application*: Simple Medical Appointments web application (`base-code` branch)
+* *Frontend*: React — any modern browser (Chrome, Firefox, Edge, Safari)
+* *Backend*: Node.js with Supabase as the database/auth provider
+* *OS*: No specific operating system dependency
+
 ===== Steps to Reproduce
 
 . Log in as a registered patient.

--- a/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
+++ b/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
@@ -1,5 +1,7 @@
 === *Defect Reporting and Management*
 
+The following is a practice defect report written to apply the defect reporting concepts covered in the "Test Case Execution and Defect Management" lecture. The bug scenario was provided as an exercise in writing a professional, reproducible defect report using all standard elements.
+
 ==== Late-Cancellation Time Slot Not Released Back to Availability
 :author: Diego Perez
 

--- a/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
+++ b/docs/Milestone_2/sections/section-LTT/subsections/4.20.adoc
@@ -11,7 +11,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 
 ===== Severity
 
-*High* - The defect directly reduces appointment availability for patients during peak demand windows, blocking bookings that would otherwise succeed. Clinics operating with limited open slots are particularly affected.
+*High.* The defect directly reduces appointment availability for patients during peak demand windows, blocking bookings that would otherwise succeed. Clinics operating with limited open slots are particularly affected.
 
 ===== Status
 
@@ -27,7 +27,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 ===== Software Configuration
 
 * *Application*: Simple Medical Appointments web application (`base-code` branch)
-* *Frontend*: React - any modern browser (Chrome, Firefox, Edge, Safari)
+* *Frontend*: React, compatible with any modern browser (Chrome, Firefox, Edge, Safari)
 * *Backend*: Node.js with Supabase as the database/auth provider
 * *OS*: No specific operating system dependency
 
@@ -37,7 +37,7 @@ Time slot remains unavailable after patient cancels appointment within 1 hour of
 . Navigate to the *Upcoming Appointments* section.
 . Select a confirmed appointment whose start time is less than 1 hour from now (e.g., appointment at 10:00, current time is 09:15).
 . Click *Cancel Appointment* and confirm the cancellation dialog.
-. Observe the appointment status - it should change to *Cancelled*.
+. Observe the appointment status. It should change to *Cancelled*.
 . Log out and log in as a different patient account (or use an incognito session).
 . Navigate to *Book an Appointment* and search for the same doctor and time slot that was just cancelled.
 . Observe whether the previously cancelled slot appears as available.
@@ -74,8 +74,8 @@ Specifically:
 
 ===== Priority
 
-*Medium* - While the severity is High, this defect occurs only under a specific time constraint (cancellation within 1 hour of the appointment). It does not affect the majority of cancellations and does not block core booking functionality. It should be addressed before release but is not a blocker for ongoing development.
+*Medium.* While the severity is High, this defect occurs only under a specific time constraint (cancellation within 1 hour of the appointment). It does not affect the majority of cancellations and does not block core booking functionality. It should be addressed before release but is not a blocker for ongoing development.
 
 ===== Root Cause
 
-*To be determined* - Suspected coding error in the cancellation handler, where the slot availability update is either skipped or conditionally blocked when the cancellation occurs within the 1-hour window. Possibly an unintended guard clause tied to the late-cancellation policy logic.
+*To be determined.* Suspected coding error in the cancellation handler, where the slot availability update is either skipped or conditionally blocked when the cancellation occurs within the 1-hour window. Possibly an unintended guard clause tied to the late-cancellation policy logic.


### PR DESCRIPTION
## Summary
- Adds a professional defect report under the *Defect Reporting and Management* section (4.20) of the Milestone 2 LTT documentation
- Documents the bug where cancelling an appointment within 1 hour of its start time fails to release the time slot back to availability
- Covers all required elements: Title, Severity, Status, Initial Configuration, Steps to Reproduce, Expected Behavior, Actual Behavior, Impact, and Proposed Solution

## Test plan
- [ ] Verify the AsciiDoc renders correctly in the documentation build
- [ ] Confirm the defect report appears under section 4.20 in the compiled output
- [ ] Check that all required report elements from Lecture 3 are present

Closes #101