### PR TITLE
Added intregation tests for admin user DELETE

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -309,7 +309,7 @@ def delete_user(user_id):
         return jsonify({"error": "Admins cannot delete their own account."}), 400
 
     def _delete(table, col, value):
-        """Run a DELETE and return (ok, error_response)."""
+        """Run a DELETE and return (ok, error_response, status)."""
         s, _, e = _supabase_request(
             "DELETE",
             f"/rest/v1/{table}",
@@ -318,7 +318,7 @@ def delete_user(user_id):
         )
         if e or s not in (200, 204, 404):
             return False, jsonify({"error": f"Failed to delete from {table}."}), 500
-        return True, None
+        return True, None, None
 
     # Step 1: Resolve doctor record (doctors table uses its own UUID, not auth user_id)
     doc_status, doc_data, _ = _supabase_request(
@@ -335,21 +335,21 @@ def delete_user(user_id):
                 ("availability_rules", "doctor_id"),
                 ("waitlist", "doctor_id"),
             ]:
-                ok, err_resp = _delete(table, col, doctor_id)
+                ok, err_resp, err_status = _delete(table, col, doctor_id)
                 if not ok:
-                    return err_resp
-            ok, err_resp = _delete("doctors", "id", doctor_id)
+                    return err_resp, err_status
+            ok, err_resp, err_status = _delete("doctors", "id", doctor_id)
             if not ok:
-                return err_resp
+                return err_resp, err_status
 
     # Step 2: Patient-linked rows (patient_id == auth user UUID)
     for table, col in [
         ("appointments", "patient_id"),
         ("waitlist", "patient_id"),
     ]:
-        ok, err_resp = _delete(table, col, user_id)
+        ok, err_resp, err_status = _delete(table, col, user_id)
         if not ok:
-            return err_resp
+            return err_resp, err_status
 
     # Step 3: Settings and role tables
     for table, col in [
@@ -358,9 +358,9 @@ def delete_user(user_id):
         ("user_roles", "user_id"),
         ("profile_settings", "user_id"),
     ]:
-        ok, err_resp = _delete(table, col, user_id)
+        ok, err_resp, err_status = _delete(table, col, user_id)
         if not ok:
-            return err_resp
+            return err_resp, err_status
 
     # Step 4: Profile-linked tables (patients, providers reference profiles.user_id)
     for table, col in [
@@ -368,9 +368,9 @@ def delete_user(user_id):
         ("providers", "user_id"),
         ("profiles", "user_id"),
     ]:
-        ok, err_resp = _delete(table, col, user_id)
+        ok, err_resp, err_status = _delete(table, col, user_id)
         if not ok:
-            return err_resp
+            return err_resp, err_status
 
     # Step 5: Delete the auth user
     auth_status, _, err = _supabase_request(

--- a/backend/tests/test_integration_admin_delete_user.py
+++ b/backend/tests/test_integration_admin_delete_user.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import patch
+
+ADMIN_USER_ID = "00000000-0000-0000-0000-000000000001"
+TARGET_USER_ID = "bbbbbbbb-0000-0000-0000-000000000002"
+
+
+def _mock_supabase_delete_success(method, path, *, query=None, json_body=None, user_token=None, prefer=None):
+    if method == "GET" and path == "/rest/v1/doctors":
+        return 200, [], None
+    if method == "DELETE" and path.startswith("/rest/v1/"):
+        return 204, None, None
+    if method == "DELETE" and path == f"/auth/v1/admin/users/{TARGET_USER_ID}":
+        return 204, None, None
+    return 200, None, None
+
+
+def _mock_supabase_delete_server_failure(method, path, *, query=None, json_body=None, user_token=None, prefer=None):
+    if method == "GET" and path == "/rest/v1/doctors":
+        return 200, [], None
+    if method == "DELETE" and path == "/rest/v1/profiles":
+        return 500, None, None
+    if method == "DELETE" and path.startswith("/rest/v1/"):
+        return 204, None, None
+    if method == "DELETE" and path == f"/auth/v1/admin/users/{TARGET_USER_ID}":
+        return 204, None, None
+    return 200, None, None
+
+
+class TestAdminDeleteUser:
+
+    def test_admin_can_delete_another_user(self, client, auth_headers):
+        with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_success), \
+             patch('app.utils.custom_decorators.get_role_for_user', return_value='admin'):
+            response = client.delete(
+                f'/api/admin/users/{TARGET_USER_ID}',
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        assert response.get_json() == {
+            'message': 'User deleted successfully.',
+            'user_id': TARGET_USER_ID,
+        }
+
+    def test_admin_cannot_delete_their_own_account(self, client, auth_headers):
+        with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_success), \
+             patch('app.utils.custom_decorators.get_role_for_user', return_value='admin'):
+            response = client.delete(
+                f'/api/admin/users/{ADMIN_USER_ID}',
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 400
+        assert response.get_json().get('error') == 'Admins cannot delete their own account.'
+
+    def test_non_admin_cannot_access_delete_route(self, client, auth_headers):
+        with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_success), \
+             patch('app.utils.custom_decorators.get_role_for_user', return_value='patient'):
+            response = client.delete(
+                f'/api/admin/users/{TARGET_USER_ID}',
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 403
+
+    def test_delete_route_returns_500_on_supabase_failure(self, client, auth_headers):
+        with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_server_failure), \
+             patch('app.utils.custom_decorators.get_role_for_user', return_value='admin'):
+            response = client.delete(
+                f'/api/admin/users/{TARGET_USER_ID}',
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 500
+        assert response.get_json().get('error') == 'Failed to delete from profiles.'


### PR DESCRIPTION
Adds backend integration tests for DELETE /api/admin/users/<user_id>.

The new tests validate authorization, self-delete protection, successful user deletion, and expected error handling for the admin delete-user route. This ensures the endpoint behaves correctly across both valid and failure scenarios.

Related Issue(s)

Closes #451 
<img width="1583" height="360" alt="image" src="https://github.com/user-attachments/assets/419548ef-9bed-448c-abfb-c378e208b1bb" />
