### PR TITLE
fix: use providers table instead of doctors in admin delete user route

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -294,7 +294,7 @@ def delete_user(user_id):
 
     Deletes records in dependency order to satisfy FK constraints:
       1. Doctor-linked rows (appointments, time_slots, availability_rules, waitlist)
-         resolved via doctors.user_id -> doctors.id
+         detected via providers.user_id; doctor_id in those tables equals user_id
       2. Patient-linked rows (appointments, waitlist by patient_id)
       3. Settings tables (patient_settings, provider_settings, profile_settings)
       4. Role table (user_roles)
@@ -320,25 +320,21 @@ def delete_user(user_id):
             return False, jsonify({"error": f"Failed to delete from {table}."}), 500
         return True, None, None
 
-    # Step 1: Resolve doctor record (doctors table uses its own UUID, not auth user_id)
-    doc_status, doc_data, _ = _supabase_request(
+    # Step 1: Doctor-linked rows (providers table stores doctor accounts; doctor_id
+    # in related tables equals the provider's user_id in the current schema)
+    prov_status, prov_data, _ = _supabase_request(
         "GET",
-        "/rest/v1/doctors",
-        query={"user_id": f"eq.{user_id}", "select": "id"},
+        "/rest/v1/providers",
+        query={"user_id": f"eq.{user_id}", "select": "user_id"},
     )
-    if doc_status == 200 and isinstance(doc_data, list) and doc_data:
-        doctor_id = doc_data[0].get("id")
-        if doctor_id:
-            for table, col in [
-                ("appointments", "doctor_id"),
-                ("time_slots", "doctor_id"),
-                ("availability_rules", "doctor_id"),
-                ("waitlist", "doctor_id"),
-            ]:
-                ok, err_resp, err_status = _delete(table, col, doctor_id)
-                if not ok:
-                    return err_resp, err_status
-            ok, err_resp, err_status = _delete("doctors", "id", doctor_id)
+    if prov_status == 200 and isinstance(prov_data, list) and prov_data:
+        for table, col in [
+            ("appointments", "doctor_id"),
+            ("time_slots", "doctor_id"),
+            ("availability_rules", "doctor_id"),
+            ("waitlist", "doctor_id"),
+        ]:
+            ok, err_resp, err_status = _delete(table, col, user_id)
             if not ok:
                 return err_resp, err_status
 

--- a/backend/tests/test_integration_admin_delete_user.py
+++ b/backend/tests/test_integration_admin_delete_user.py
@@ -6,7 +6,7 @@ TARGET_USER_ID = "bbbbbbbb-0000-0000-0000-000000000002"
 
 
 def _mock_supabase_delete_success(method, path, *, query=None, json_body=None, user_token=None, prefer=None):
-    if method == "GET" and path == "/rest/v1/doctors":
+    if method == "GET" and path == "/rest/v1/providers":
         return 200, [], None
     if method == "DELETE" and path.startswith("/rest/v1/"):
         return 204, None, None
@@ -15,8 +15,18 @@ def _mock_supabase_delete_success(method, path, *, query=None, json_body=None, u
     return 200, None, None
 
 
+def _mock_supabase_delete_doctor_success(method, path, *, query=None, json_body=None, user_token=None, prefer=None):
+    if method == "GET" and path == "/rest/v1/providers":
+        return 200, [{"user_id": TARGET_USER_ID}], None
+    if method == "DELETE" and path.startswith("/rest/v1/"):
+        return 204, None, None
+    if method == "DELETE" and path == f"/auth/v1/admin/users/{TARGET_USER_ID}":
+        return 204, None, None
+    return 200, None, None
+
+
 def _mock_supabase_delete_server_failure(method, path, *, query=None, json_body=None, user_token=None, prefer=None):
-    if method == "GET" and path == "/rest/v1/doctors":
+    if method == "GET" and path == "/rest/v1/providers":
         return 200, [], None
     if method == "DELETE" and path == "/rest/v1/profiles":
         return 500, None, None
@@ -63,6 +73,20 @@ class TestAdminDeleteUser:
             )
 
         assert response.status_code == 403
+
+    def test_admin_can_delete_doctor_account(self, client, auth_headers):
+        with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_doctor_success), \
+             patch('app.utils.custom_decorators.get_role_for_user', return_value='admin'):
+            response = client.delete(
+                f'/api/admin/users/{TARGET_USER_ID}',
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        assert response.get_json() == {
+            'message': 'User deleted successfully.',
+            'user_id': TARGET_USER_ID,
+        }
 
     def test_delete_route_returns_500_on_supabase_failure(self, client, auth_headers):
         with patch('app.routes.admin._supabase_request', side_effect=_mock_supabase_delete_server_failure), \


### PR DESCRIPTION
The DELETE /api/admin/users/<user_id> route was looking up doctor data in the old doctors table, which is no longer
  populated by the current signup flow. Doctor accounts are now stored in providers. This fix updates Step 1 of the       delete flow to check providers by user_id and use user_id directly as the doctor_id when cleaning up related records
  (appointments, time_slots, availability_rules, waitlist). Also updates test mocks to reflect the new provider data      path and adds a dedicated test for doctor account deletion. Closes #421.