### PR TITLE
Implemented Doctor/Admin Booking Logic

### DIFF
--- a/backend/app/repositories/availability.py
+++ b/backend/app/repositories/availability.py
@@ -12,7 +12,7 @@ from ..services.scheduling import DailyAvailability, TimeRange
 from ..services.working_hours import ensure_non_overlapping_ranges, parse_time_value
 
 
-def _supabase_request(method, path, *, query=None):
+def _supabase_request(method, path, *, query=None, json_body=None):
     base_url = (current_app.config.get("SUPABASE_URL") or "").rstrip("/")
     service_key = current_app.config.get("SUPABASE_SERVICE_ROLE_KEY")
 
@@ -28,7 +28,13 @@ def _supabase_request(method, path, *, query=None):
         "Authorization": f"Bearer {service_key}",
     }
 
-    req = Request(url=url, headers=headers, method=method)
+    body = None
+    if json_body is not None:
+        body = json.dumps(json_body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+        headers["Prefer"] = "return=representation"
+
+    req = Request(url=url, headers=headers, method=method, data=body)
 
     try:
         with urlopen(req, timeout=20) as resp:

--- a/backend/app/repositories/slot_bookings.py
+++ b/backend/app/repositories/slot_bookings.py
@@ -1,38 +1,376 @@
-"""Per-slot booking counts (stub) plus helpers to list/reserve slots with capacity rules."""
+"""Helpers to list and book appointment slots with capacity rules.
+
+Doctor/admin slot booking logic.
+
+Per-slot booking logic to list/reserve slots following this order:
+
+MAIN at requested slot
+→ WAITLIST at next available slot on the same day, if accepted
+→ OVERRIDE at requested slot, if explicitly allowed
+→ REJECT
+"""
 
 from __future__ import annotations
 
-from datetime import date, datetime, time
-from threading import Lock
+from datetime import date, datetime, time, timedelta
+from typing import Literal
 
-from .availability import get_availability_for_doctor_date
+from .availability import get_availability_for_doctor_date, _supabase_request
 from ..services.scheduling import generate_available_slots
 
-_lock = Lock()
-# (doctor_id, date_iso, "HH:MM") -> count
-_counts: dict[tuple[str, str, str], int] = {}
+BookingType = Literal["MAIN", "WAITLIST", "OVERRIDE"]
+
+ACTIVE_STATUSES = ("pending", "confirmed")
+
+DEFAULT_WAITLIST_CAPACITY_PER_DAY = 3
 
 
-def _key(doctor_id: str, slot_start: datetime) -> tuple[str, str, str]:
-    return (doctor_id, slot_start.date().isoformat(), slot_start.strftime("%H:%M"))
+def _normalize_dt(value: datetime) -> str:
+    """Format datetime consistently for Supabase comparisons/inserts."""
+    return value.isoformat()
 
 
-def get_booking_count(doctor_id: str, slot_start: datetime) -> int:
-    with _lock:
-        return _counts.get(_key(doctor_id, slot_start), 0)
+def _validate_requested_slot(
+    doctor_id: str,
+    day: date,
+    start_time: time,
+) -> tuple[datetime | None, dict | None, int | None]:
+    availability = get_availability_for_doctor_date(doctor_id, day)
+    requested_slot = datetime.combine(day, start_time)
+
+    allowed_slots = set(generate_available_slots(availability))
+
+    if requested_slot not in allowed_slots:
+        return (
+            None,
+            {"error": "Requested time is not an available generated slot for this doctor/date."},
+            400,
+        )
+
+    return requested_slot, None, None
 
 
-def increment_booking(doctor_id: str, slot_start: datetime) -> int:
-    """Increment bookings for this slot; return the new total."""
-    with _lock:
-        k = _key(doctor_id, slot_start)
-        _counts[k] = _counts.get(k, 0) + 1
-        return _counts[k]
+def _get_doctor_clinic_id(doctor_id: str) -> str | None:
+    status, data, err = _supabase_request(
+        "GET",
+        "/rest/v1/doctors",
+        query={
+            "id": f"eq.{doctor_id}",
+            "select": "clinic_id",
+            "limit": "1",
+        },
+    )
+
+    if err or status != 200 or not data:
+        return None
+
+    return data[0].get("clinic_id")
 
 
-def slot_time_strings_for_doctor_day(doctor_id: str, day: date) -> list[str]:
-    """HH:MM strings for the UI — calendar rules minus slots already at capacity."""
-    return [dt.strftime("%H:%M") for dt in _slot_starts_with_room(doctor_id, day)]
+def _get_main_capacity(doctor_id: str, day: date) -> int:
+    availability = get_availability_for_doctor_date(doctor_id, day)
+    return availability.max_appointments_per_slot
+
+
+def _count_appointments_by_type(
+    doctor_id: str,
+    appointment_datetime: datetime,
+) -> dict[str, int]:
+    status, data, err = _supabase_request(
+        "GET",
+        "/rest/v1/appointments",
+        query={
+            "doctor_id": f"eq.{doctor_id}",
+            "appointment_datetime": f"eq.{_normalize_dt(appointment_datetime)}",
+            "status": f"in.({','.join(ACTIVE_STATUSES)})",
+            "select": "appointment_type",
+        },
+    )
+
+    counts = {
+        "MAIN": 0,
+        "WAITLIST": 0,
+        "OVERRIDE": 0,
+    }
+
+    if err or status != 200:
+        return counts
+
+    for row in data or []:
+        appointment_type = (row.get("appointment_type") or "MAIN").upper()
+        if appointment_type in counts:
+            counts[appointment_type] += 1
+
+    return counts
+
+
+def _regular_slot_usage(counts: dict[str, int]) -> int:
+    """Appointments that consume normal slot capacity."""
+    return counts["MAIN"] + counts["WAITLIST"]
+
+
+def _slot_has_regular_capacity(
+    doctor_id: str,
+    slot_start: datetime,
+    main_capacity: int,
+) -> bool:
+    counts = _count_appointments_by_type(doctor_id, slot_start)
+    return _regular_slot_usage(counts) < main_capacity
+
+
+def _count_waitlist_for_day(doctor_id: str, day: date) -> int:
+    day_start = datetime.combine(day, time.min)
+    day_end = day_start + timedelta(days=1)
+
+    status, data, err = _supabase_request(
+        "GET",
+        "/rest/v1/appointments",
+        query={
+            "doctor_id": f"eq.{doctor_id}",
+            "appointment_type": "eq.WAITLIST",
+            "status": f"in.({','.join(ACTIVE_STATUSES)})",
+            "select": "id,appointment_datetime",
+        },
+    )
+
+    if err or status != 200:
+        return 0
+
+    count = 0
+    for row in data or []:
+        raw_dt = row.get("appointment_datetime")
+        if not raw_dt:
+            continue
+
+        try:
+            appt_dt = datetime.fromisoformat(raw_dt.replace("Z", "+00:00")).replace(tzinfo=None)
+        except ValueError:
+            continue
+
+        if day_start <= appt_dt < day_end:
+            count += 1
+
+    return count
+
+
+def _find_next_available_slot_same_day(
+    doctor_id: str,
+    day: date,
+    requested_slot: datetime,
+) -> datetime | None:
+    availability = get_availability_for_doctor_date(doctor_id, day)
+    generated_slots = generate_available_slots(availability)
+    main_capacity = availability.max_appointments_per_slot
+
+    for slot_start in generated_slots:
+        if slot_start <= requested_slot:
+            continue
+
+        if _slot_has_regular_capacity(doctor_id, slot_start, main_capacity):
+            return slot_start
+
+    return None
+
+
+def _insert_appointment(
+    *,
+    patient_id: str,
+    doctor_id: str,
+    clinic_id: str,
+    appointment_datetime: datetime,
+    appointment_type: BookingType,
+    notes: str | None = None,
+) -> tuple[dict | None, tuple[dict, int] | None]:
+    payload = {
+        "patient_id": patient_id,
+        "doctor_id": doctor_id,
+        "clinic_id": clinic_id,
+        "appointment_datetime": _normalize_dt(appointment_datetime),
+        "status": "confirmed",
+        "appointment_type": appointment_type,
+        "notes": notes,
+    }
+
+    status, data, err = _supabase_request(
+        "POST",
+        "/rest/v1/appointments",
+        query={"select": "*"},
+        json_body=payload,
+    )
+
+    if err:
+        return None, ({"error": "Failed to create appointment", "details": err}, 500)
+
+    if status not in (200, 201) or not data:
+        return None, (
+            {
+                "error": "Failed to create appointment",
+                "details": data,
+            },
+            500,
+        )
+
+    return data[0], None
+
+
+def book_admin_appointment(
+    *,
+    patient_id: str,
+    doctor_id: str,
+    appointment_date: date,
+    appointment_time: time,
+    notes: str | None = None,
+    accept_waitlist: bool = False,
+    allow_override: bool = False,
+) -> tuple[dict | None, tuple[dict, int] | None]:
+    """Book appointment for doctor/admin workflow.
+
+    Flow:
+    1. Book MAIN at requested slot if normal capacity exists.
+    2. If requested slot is full and accept_waitlist is true, assign next available
+       slot on the same day as WAITLIST, subject to a daily waitlist limit.
+    3. If no waitlist placement is possible and allow_override is true, book
+       OVERRIDE at the requested slot.
+    4. Otherwise reject.
+    """
+    requested_slot, error_body, error_status = _validate_requested_slot(
+        doctor_id,
+        appointment_date,
+        appointment_time,
+    )
+
+    if error_body is not None:
+        return None, (error_body, error_status or 400)
+
+    clinic_id = _get_doctor_clinic_id(doctor_id)
+    if not clinic_id:
+        return None, (
+            {"error": "Could not determine clinic for selected doctor."},
+            400,
+        )
+
+    main_capacity = _get_main_capacity(doctor_id, appointment_date)
+    requested_counts = _count_appointments_by_type(doctor_id, requested_slot)
+
+    # 1. MAIN booking at requested slot.
+    if _regular_slot_usage(requested_counts) < main_capacity:
+        appointment, insert_error = _insert_appointment(
+            patient_id=patient_id,
+            doctor_id=doctor_id,
+            clinic_id=clinic_id,
+            appointment_datetime=requested_slot,
+            appointment_type="MAIN",
+            notes=notes,
+        )
+
+        if insert_error is not None:
+            return None, insert_error
+
+        return (
+            {
+                "appointment": appointment,
+                "booking_type": "MAIN",
+                "assigned_datetime": _normalize_dt(requested_slot),
+                "requested_datetime": _normalize_dt(requested_slot),
+                "message": "Appointment booked in requested slot.",
+            },
+            None,
+        )
+
+    # 2. WAITLIST booking into next available slot that same day.
+    if accept_waitlist:
+        daily_waitlist_count = _count_waitlist_for_day(doctor_id, appointment_date)
+
+        if daily_waitlist_count >= DEFAULT_WAITLIST_CAPACITY_PER_DAY:
+            waitlist_error = {
+                "error": "Daily waitlist capacity has been reached.",
+                "waitlist_capacity_per_day": DEFAULT_WAITLIST_CAPACITY_PER_DAY,
+            }
+        else:
+            next_slot = _find_next_available_slot_same_day(
+                doctor_id,
+                appointment_date,
+                requested_slot,
+            )
+
+            if next_slot is not None:
+                waitlist_notes = notes or ""
+                waitlist_notes = (
+                    f"{waitlist_notes}\nPreferred time was "
+                    f"{requested_slot.strftime('%H:%M')}; assigned to next available slot."
+                ).strip()
+
+                appointment, insert_error = _insert_appointment(
+                    patient_id=patient_id,
+                    doctor_id=doctor_id,
+                    clinic_id=clinic_id,
+                    appointment_datetime=next_slot,
+                    appointment_type="WAITLIST",
+                    notes=waitlist_notes,
+                )
+
+                if insert_error is not None:
+                    return None, insert_error
+
+                return (
+                    {
+                        "appointment": appointment,
+                        "booking_type": "WAITLIST",
+                        "assigned_datetime": _normalize_dt(next_slot),
+                        "requested_datetime": _normalize_dt(requested_slot),
+                        "message": "Requested slot was full. Patient was assigned to the next available slot on the same day.",
+                    },
+                    None,
+                )
+
+            waitlist_error = {
+                "error": "No next available slot found for waitlist placement on this day."
+            }
+    else:
+        waitlist_error = {
+            "error": "Requested slot is full and waitlist placement was not accepted."
+        }
+
+    # 3. OVERRIDE booking at requested slot, only if explicitly allowed.
+    if allow_override:
+        override_notes = notes or ""
+        override_notes = (
+            f"{override_notes}\nOverride approved for full requested slot."
+        ).strip()
+
+        appointment, insert_error = _insert_appointment(
+            patient_id=patient_id,
+            doctor_id=doctor_id,
+            clinic_id=clinic_id,
+            appointment_datetime=requested_slot,
+            appointment_type="OVERRIDE",
+            notes=override_notes,
+        )
+
+        if insert_error is not None:
+            return None, insert_error
+
+        return (
+            {
+                "appointment": appointment,
+                "booking_type": "OVERRIDE",
+                "assigned_datetime": _normalize_dt(requested_slot),
+                "requested_datetime": _normalize_dt(requested_slot),
+                "message": "Requested slot was full. Appointment was booked through admin override.",
+            },
+            None,
+        )
+
+    # 4. REJECT.
+    return None, (
+        {
+            "error": "Unable to book appointment.",
+            "details": waitlist_error,
+            "requested_slot_counts": requested_counts,
+            "main_capacity": main_capacity,
+        },
+        409,
+    )
 
 
 def try_reserve_slot(
@@ -40,52 +378,56 @@ def try_reserve_slot(
     day: date,
     start_time: time,
 ) -> tuple[dict, int] | None:
-    """Record one booking in a slot, or return (error JSON, HTTP status)."""
-    rules = get_availability_for_doctor_date(doctor_id, day)
-    slot_start = datetime.combine(day, start_time)
-    allowed_starts = set(generate_available_slots(rules))
-    if slot_start not in allowed_starts:
-        return (
-            {"error": "Requested time is not an available slot for this doctor/date"},
-            400,
-        )
-    cap = rules.max_appointments_per_slot
-    if get_booking_count(doctor_id, slot_start) >= cap:
+    """Compatibility wrapper for the older /submit route.
+
+    This only validates requested slot availability for MAIN booking.
+    New doctor/admin booking should use book_admin_appointment().
+    """
+    requested_slot, error_body, error_status = _validate_requested_slot(
+        doctor_id,
+        day,
+        start_time,
+    )
+
+    if error_body is not None:
+        return error_body, error_status or 400
+
+    main_capacity = _get_main_capacity(doctor_id, day)
+    counts = _count_appointments_by_type(doctor_id, requested_slot)
+
+    if _regular_slot_usage(counts) >= main_capacity:
         return (
             {
                 "error": "This time slot is full",
-                "max_appointments_per_slot": cap,
+                "max_appointments_per_slot": main_capacity,
             },
             409,
         )
-    increment_booking(doctor_id, slot_start)
+
     return None
 
 
-def decrement_booking(doctor_id: str, slot_start: datetime) -> int:
-    """Release one seat (e.g. appointment cancelled). Returns the new count."""
-    with _lock:
-        k = _key(doctor_id, slot_start)
-        current = _counts.get(k, 0)
-        if current <= 0:
-            return 0
-        _counts[k] = current - 1
-        if _counts[k] == 0:
-            del _counts[k]
-        return _counts.get(k, 0)
+def slot_time_strings_for_doctor_day(doctor_id: str, day: date) -> list[str]:
+    """Return HH:MM strings for generated slots that still have regular capacity."""
+    availability = get_availability_for_doctor_date(doctor_id, day)
+    main_capacity = availability.max_appointments_per_slot
+
+    available_times = []
+
+    for slot_start in generate_available_slots(availability):
+        counts = _count_appointments_by_type(doctor_id, slot_start)
+
+        if _regular_slot_usage(counts) < main_capacity:
+            available_times.append(slot_start.strftime("%H:%M"))
+
+    return available_times
 
 
 def reset_booking_counts() -> None:
-    """Clear all counts — used between tests."""
-    with _lock:
-        _counts.clear()
+    """
+    Compatibility helper for tests.
 
-
-def _slot_starts_with_room(doctor_id: str, day: date) -> list[datetime]:
-    rules = get_availability_for_doctor_date(doctor_id, day)
-    cap = rules.max_appointments_per_slot
-    return [
-        s
-        for s in generate_available_slots(rules)
-        if get_booking_count(doctor_id, s) < cap
-    ]
+    Booking counts are no longer stored in memory; they are calculated from
+    appointment records. Test data should be reset through test fixtures.
+    """
+    return None

--- a/backend/app/routes/appointments.py
+++ b/backend/app/routes/appointments.py
@@ -8,6 +8,7 @@ from datetime import date, time, datetime
 from flask import Blueprint, request, jsonify
 from app.middleware.auth_middleware import requires_auth
 from app.repositories.slot_bookings import try_reserve_slot
+from app.repositories.slot_bookings import book_admin_appointment
 
 from app.models import db, Appointment, AppointmentStatus, SlotStatus
 
@@ -202,3 +203,49 @@ def cancel_appointment(appointment_id):
             "appointment": appt.to_dict(),
         }
     ), 200
+
+@appointments_bp.route('/admin/book', methods=['POST'])
+@requires_auth
+def admin_book_appointment():
+    if not request.is_json:
+        return jsonify({'error': 'Request body must be JSON'}), 415
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'error': 'Invalid or empty JSON body'}), 415
+
+    required = ['patient_id', 'doctor_id', 'appointment_date', 'appointment_time']
+    missing = [field for field in required if not data.get(field)]
+
+    if missing:
+        return jsonify({'error': 'Missing required fields', 'fields': missing}), 400
+
+    try:
+        appt_date = date.fromisoformat(str(data['appointment_date']).strip())
+    except ValueError:
+        return jsonify({'error': 'Invalid appointment_date; use YYYY-MM-DD'}), 400
+
+    try:
+        appt_time = time.fromisoformat(str(data['appointment_time']).strip())
+    except ValueError:
+        return jsonify({'error': 'Invalid appointment_time; use HH:MM'}), 400
+
+    result, err = book_admin_appointment(
+        patient_id=str(data['patient_id']).strip(),
+        doctor_id=str(data['doctor_id']).strip(),
+        appointment_date=appt_date,
+        appointment_time=appt_time,
+        notes=data.get('notes'),
+        accept_waitlist=bool(data.get('accept_waitlist', False)),
+        allow_override=bool(data.get('allow_override', False)),
+    )
+
+    if err is not None:
+        body, status = err
+        return jsonify(body), status
+
+    return jsonify({
+        'success': True,
+        'message': 'Appointment booked successfully.',
+        'data': result,
+    }), 201

--- a/backend/tests/test_admin_booking_logic.py
+++ b/backend/tests/test_admin_booking_logic.py
@@ -1,0 +1,255 @@
+from datetime import date, time
+
+import pytest
+
+from app import create_app
+from app.repositories import availability
+from app.repositories import slot_bookings
+
+
+@pytest.fixture
+def app_context():
+    app = create_app()
+    with app.app_context():
+        yield
+
+
+@pytest.fixture
+def fake_supabase(monkeypatch):
+    fake_appointments = []
+
+    def fake_supabase_request(method, path, *, query=None, json_body=None):
+        query = query or {}
+
+        # Fake availability rules: doctor works Monday 9 AM - 5 PM.
+        if method == "GET" and path == "/rest/v1/availability_rules":
+            return 200, [
+                {
+                    "start_time": "09:00:00",
+                    "end_time": "17:00:00",
+                }
+            ], None
+
+        # Fake doctor lookups.
+        if method == "GET" and path == "/rest/v1/doctors":
+            if query.get("select") == "clinic_id":
+                return 200, [{"clinic_id": "fake-clinic-id"}], None
+
+            if query.get("select") == "user_id":
+                return 200, [{"user_id": "fake-user-id"}], None
+
+        # Fake provider settings.
+        if method == "GET" and path == "/rest/v1/provider_settings":
+            return 200, [{"default_appointment_duration": 30}], None
+
+        # Fake appointment query/counting.
+        if method == "GET" and path == "/rest/v1/appointments":
+            doctor_id = query.get("doctor_id", "").replace("eq.", "")
+            appointment_datetime = query.get("appointment_datetime", "").replace("eq.", "")
+            appointment_type_filter = query.get("appointment_type", "")
+
+            results = [
+                appt for appt in fake_appointments
+                if appt["doctor_id"] == doctor_id
+            ]
+
+            if appointment_datetime:
+                results = [
+                    appt for appt in results
+                    if appt["appointment_datetime"] == appointment_datetime
+                ]
+
+            if appointment_type_filter == "eq.WAITLIST":
+                results = [
+                    appt for appt in results
+                    if appt["appointment_type"] == "WAITLIST"
+                ]
+
+            return 200, results, None
+
+        # Fake appointment insert.
+        if method == "POST" and path == "/rest/v1/appointments":
+            new_appointment = dict(json_body)
+            new_appointment["id"] = len(fake_appointments) + 1
+            fake_appointments.append(new_appointment)
+            return 201, [new_appointment], None
+
+        return 404, None, f"Unhandled fake request: {method} {path}"
+
+    # Patch both modules because slot_bookings imports _supabase_request directly.
+    monkeypatch.setattr(availability, "_supabase_request", fake_supabase_request)
+    monkeypatch.setattr(slot_bookings, "_supabase_request", fake_supabase_request)
+
+    return fake_appointments
+
+
+def test_first_booking_goes_to_main(app_context, fake_supabase):
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(9, 0),
+        accept_waitlist=True,
+        allow_override=False,
+        notes="Test main booking",
+    )
+
+    assert err is None
+    assert result["booking_type"] == "MAIN"
+    assert result["appointment"]["appointment_type"] == "MAIN"
+    assert result["appointment"]["appointment_datetime"] == "2026-05-25T09:00:00"
+    assert len(fake_supabase) == 1
+
+
+def test_third_booking_goes_to_waitlist_next_available_slot(app_context, fake_supabase):
+    # First two bookings fill the requested 09:00 slot.
+    for _ in range(2):
+        result, err = slot_bookings.book_admin_appointment(
+            patient_id="fake-patient-id",
+            doctor_id="fake-doctor-id",
+            appointment_date=date(2026, 5, 25),
+            appointment_time=time(9, 0),
+            accept_waitlist=True,
+            allow_override=False,
+        )
+        assert err is None
+        assert result["booking_type"] == "MAIN"
+
+    # Third booking should be moved to next available slot as WAITLIST.
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(9, 0),
+        accept_waitlist=True,
+        allow_override=False,
+        notes="Test waitlist booking",
+    )
+
+    assert err is None
+    assert result["booking_type"] == "WAITLIST"
+    assert result["appointment"]["appointment_type"] == "WAITLIST"
+    assert result["requested_datetime"] == "2026-05-25T09:00:00"
+    assert result["assigned_datetime"] == "2026-05-25T09:30:00"
+    assert len(fake_supabase) == 3
+
+
+def test_full_slot_without_waitlist_or_override_is_rejected(app_context, fake_supabase):
+    # Fill 09:00.
+    for _ in range(2):
+        result, err = slot_bookings.book_admin_appointment(
+            patient_id="fake-patient-id",
+            doctor_id="fake-doctor-id",
+            appointment_date=date(2026, 5, 25),
+            appointment_time=time(9, 0),
+            accept_waitlist=False,
+            allow_override=False,
+        )
+        assert err is None
+
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(9, 0),
+        accept_waitlist=False,
+        allow_override=False,
+    )
+
+    assert result is None
+    assert err is not None
+
+    body, status = err
+    assert status == 409
+    assert body["error"] == "Unable to book appointment."
+
+
+def test_full_slot_with_override_books_override(app_context, fake_supabase):
+    # Fill 09:00.
+    for _ in range(2):
+        result, err = slot_bookings.book_admin_appointment(
+            patient_id="fake-patient-id",
+            doctor_id="fake-doctor-id",
+            appointment_date=date(2026, 5, 25),
+            appointment_time=time(9, 0),
+            accept_waitlist=False,
+            allow_override=False,
+        )
+        assert err is None
+
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(9, 0),
+        accept_waitlist=False,
+        allow_override=True,
+        notes="Admin approved override",
+    )
+
+    assert err is None
+    assert result["booking_type"] == "OVERRIDE"
+    assert result["appointment"]["appointment_type"] == "OVERRIDE"
+    assert result["assigned_datetime"] == "2026-05-25T09:00:00"
+
+
+def test_invalid_slot_is_rejected(app_context, fake_supabase):
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(8, 0),  # Before generated working hours.
+        accept_waitlist=True,
+        allow_override=False,
+    )
+
+    assert result is None
+    assert err is not None
+
+    body, status = err
+    assert status == 400
+    assert "not an available generated slot" in body["error"]
+
+
+def test_daily_waitlist_capacity_is_enforced(app_context, fake_supabase):
+    # Fill 09:00.
+    for _ in range(2):
+        result, err = slot_bookings.book_admin_appointment(
+            patient_id="fake-patient-id",
+            doctor_id="fake-doctor-id",
+            appointment_date=date(2026, 5, 25),
+            appointment_time=time(9, 0),
+            accept_waitlist=True,
+            allow_override=False,
+        )
+        assert err is None
+
+    # Create 3 waitlist bookings, which matches DEFAULT_WAITLIST_CAPACITY_PER_DAY.
+    for _ in range(3):
+        result, err = slot_bookings.book_admin_appointment(
+            patient_id="fake-patient-id",
+            doctor_id="fake-doctor-id",
+            appointment_date=date(2026, 5, 25),
+            appointment_time=time(9, 0),
+            accept_waitlist=True,
+            allow_override=False,
+        )
+        assert err is None
+        assert result["booking_type"] == "WAITLIST"
+
+    # Next waitlist attempt should be rejected because daily waitlist cap is reached.
+    result, err = slot_bookings.book_admin_appointment(
+        patient_id="fake-patient-id",
+        doctor_id="fake-doctor-id",
+        appointment_date=date(2026, 5, 25),
+        appointment_time=time(9, 0),
+        accept_waitlist=True,
+        allow_override=False,
+    )
+
+    assert result is None
+    assert err is not None
+
+    body, status = err
+    assert status == 409
+    assert body["details"]["error"] == "Daily waitlist capacity has been reached."

--- a/backend/tests/test_slot_capacity_state_transitions.py
+++ b/backend/tests/test_slot_capacity_state_transitions.py
@@ -4,13 +4,14 @@ State-transition tests for per-slot booking capacity (Lecture: Test Preparation)
 States: AVAILABLE (0 bookings) -> PARTIAL -> FULL -> (release) -> PARTIAL/AVAILABLE.
 """
 
-from datetime import date, time
+from datetime import date, datetime, time
 
 import pytest
 
+from app import create_app
+from app.repositories import availability
+from app.repositories import slot_bookings
 from app.repositories.slot_bookings import (
-    decrement_booking,
-    get_booking_count,
     slot_time_strings_for_doctor_day,
     try_reserve_slot,
 )
@@ -20,56 +21,181 @@ DAY = date(2026, 3, 9)
 SLOT = time(9, 0)
 
 
+@pytest.fixture
+def app_context():
+    app = create_app()
+    with app.app_context():
+        yield
+
+
+@pytest.fixture
+def fake_supabase(monkeypatch):
+    fake_appointments = []
+
+    def fake_supabase_request(method, path, *, query=None, json_body=None):
+        query = query or {}
+
+        if method == "GET" and path == "/rest/v1/availability_rules":
+            return 200, [
+                {
+                    "start_time": "09:00:00",
+                    "end_time": "17:00:00",
+                }
+            ], None
+
+        if method == "GET" and path == "/rest/v1/doctors":
+            if query.get("select") == "clinic_id":
+                return 200, [{"clinic_id": "fake-clinic-id"}], None
+
+            if query.get("select") == "user_id":
+                return 200, [{"user_id": "fake-user-id"}], None
+
+        if method == "GET" and path == "/rest/v1/provider_settings":
+            return 200, [{"default_appointment_duration": 30}], None
+
+        if method == "GET" and path == "/rest/v1/appointments":
+            doctor_id = query.get("doctor_id", "").replace("eq.", "")
+            appointment_datetime = query.get("appointment_datetime", "").replace("eq.", "")
+            appointment_type_filter = query.get("appointment_type", "")
+            status_filter = query.get("status", "")
+
+            results = [
+                appt for appt in fake_appointments
+                if appt["doctor_id"] == doctor_id
+            ]
+
+            if appointment_datetime:
+                results = [
+                    appt for appt in results
+                    if appt["appointment_datetime"] == appointment_datetime
+                ]
+
+            if appointment_type_filter == "eq.WAITLIST":
+                results = [
+                    appt for appt in results
+                    if appt["appointment_type"] == "WAITLIST"
+                ]
+
+            if status_filter == "in.(pending,confirmed)":
+                    results = [
+                        appt for appt in results
+                        if appt.get("status") in ("pending", "confirmed")
+                    ]
+
+            return 200, results, None
+
+        if method == "POST" and path == "/rest/v1/appointments":
+            new_appointment = dict(json_body)
+            new_appointment["id"] = len(fake_appointments) + 1
+            fake_appointments.append(new_appointment)
+            return 201, [new_appointment], None
+
+        return 404, None, f"Unhandled fake request: {method} {path}"
+
+    monkeypatch.setattr(availability, "_supabase_request", fake_supabase_request)
+    monkeypatch.setattr(slot_bookings, "_supabase_request", fake_supabase_request)
+
+    return fake_appointments
+
+
+def _slot_datetime():
+    return datetime.combine(DAY, SLOT).isoformat()
+
+
 def _reserve():
     return try_reserve_slot(DOCTOR, DAY, SLOT)
 
 
-class TestSlotCapacityStateTransitions:
-    def test_available_to_partial_to_full(self):
-        assert get_booking_count(DOCTOR, _slot_start()) == 0
-        assert _reserve() is None
-        assert get_booking_count(DOCTOR, _slot_start()) == 1
+def _insert_fake_main_booking(fake_appointments):
+    fake_appointments.append(
+        {
+            "id": len(fake_appointments) + 1,
+            "patient_id": f"patient-{len(fake_appointments) + 1}",
+            "doctor_id": DOCTOR,
+            "clinic_id": "fake-clinic-id",
+            "appointment_datetime": _slot_datetime(),
+            "status": "confirmed",
+            "appointment_type": "MAIN",
+            "notes": None,
+        }
+    )
 
+
+def _count_bookings_for_slot(fake_appointments):
+    return len(
+        [
+            appt for appt in fake_appointments
+            if appt["doctor_id"] == DOCTOR
+            and appt["appointment_datetime"] == _slot_datetime()
+            and appt["status"] in ("pending", "confirmed")
+        ]
+    )
+
+def _cancel_one_booking(fake_appointments):
+    for appt in fake_appointments:
+        if (
+            appt["doctor_id"] == DOCTOR
+            and appt["appointment_datetime"] == _slot_datetime()
+            and appt["status"] in ("pending", "confirmed")
+        ):
+            appt["status"] = "cancelled"
+            return
+class TestSlotCapacityStateTransitions:
+    def test_available_to_partial_to_full(self, app_context, fake_supabase):
+        assert _count_bookings_for_slot(fake_supabase) == 0
         assert _reserve() is None
-        assert get_booking_count(DOCTOR, _slot_start()) == 2
+
+        _insert_fake_main_booking(fake_supabase)
+        assert _count_bookings_for_slot(fake_supabase) == 1
+        assert _reserve() is None
+
+        _insert_fake_main_booking(fake_supabase)
+        assert _count_bookings_for_slot(fake_supabase) == 2
 
         body, status = _reserve()
         assert status == 409
         assert "full" in body["error"].lower()
 
-    def test_full_slot_hidden_from_available_slots_list(self):
-        for _ in range(2):
-            assert _reserve() is None
+    def test_full_slot_hidden_from_available_slots_list(self, app_context, fake_supabase):
+        _insert_fake_main_booking(fake_supabase)
+        _insert_fake_main_booking(fake_supabase)
 
         slots = slot_time_strings_for_doctor_day(DOCTOR, DAY)
+
         assert "09:00" not in slots
         assert "09:30" in slots
 
-    def test_full_to_partial_allows_one_more_booking(self):
-        for _ in range(2):
-            assert _reserve() is None
-        decrement_booking(DOCTOR, _slot_start())
-
-        assert get_booking_count(DOCTOR, _slot_start()) == 1
-        assert _reserve() is None
-        assert get_booking_count(DOCTOR, _slot_start()) == 2
+    def test_full_to_partial_allows_one_more_booking(self, app_context, fake_supabase):
+        _insert_fake_main_booking(fake_supabase)
+        _insert_fake_main_booking(fake_supabase)
 
         body, status = _reserve()
         assert status == 409
 
-    def test_partial_to_available_after_cancellation(self):
+        _cancel_one_booking(fake_supabase)
+        assert _count_bookings_for_slot(fake_supabase) == 1
+
         assert _reserve() is None
-        decrement_booking(DOCTOR, _slot_start())
-        assert get_booking_count(DOCTOR, _slot_start()) == 0
+
+        _insert_fake_main_booking(fake_supabase)
+        assert _count_bookings_for_slot(fake_supabase) == 2
+
+        body, status = _reserve()
+        assert status == 409
+
+
+    def test_partial_to_available_after_cancellation(self, app_context, fake_supabase):
+        _insert_fake_main_booking(fake_supabase)
+
         assert "09:00" in slot_time_strings_for_doctor_day(DOCTOR, DAY)
 
-    def test_invalid_slot_time_stays_rejected_from_any_state(self):
-        body, status = try_reserve_slot(DOCTOR, DAY, time(12, 0))
+        _cancel_one_booking(fake_supabase)
+
+        assert _count_bookings_for_slot(fake_supabase) == 0
+        assert "09:00" in slot_time_strings_for_doctor_day(DOCTOR, DAY)
+
+    def test_invalid_slot_time_stays_rejected_from_any_state(self, app_context, fake_supabase):
+        body, status = try_reserve_slot(DOCTOR, DAY, time(8, 0))
+
         assert status == 400
-        assert get_booking_count(DOCTOR, _slot_start()) == 0
-
-
-def _slot_start():
-    from datetime import datetime
-
-    return datetime.combine(DAY, SLOT)
+        assert _count_bookings_for_slot(fake_supabase) == 0


### PR DESCRIPTION
### **Closes #544** 

**Changes made:** 

Implemented the core doctor/admin booking logic for appointment capacity handling.

**This includes:**
- MAIN booking when the requested slot has available capacity
- WAITLIST placement when the requested slot is full and waitlist capacity is available
- OVERRIDE booking when explicitly allowed
- Rejection when no valid booking option is available
- Implemented Supabase-backed appointment counting instead of in-memory counts
- Updated tests for booking flow and slot capacity state transitions

**Tests created/updated for local verification, both of which pass:**
- python -m pytest tests/test_admin_booking_logic.py -v
- python -m pytest tests/test_slot_capacity_state_transitions.py -v