### PR TITLE
Same sourced backend scheduling

### DIFF
--- a/backend/app/repositories/slot_bookings.py
+++ b/backend/app/repositories/slot_bookings.py
@@ -179,6 +179,7 @@ def _insert_appointment(
     clinic_id: str,
     appointment_datetime: datetime,
     appointment_type: BookingType,
+    status: Literal["pending", "confirmed"] = "confirmed",
     notes: str | None = None,
 ) -> tuple[dict | None, tuple[dict, int] | None]:
     payload = {
@@ -186,7 +187,7 @@ def _insert_appointment(
         "doctor_id": doctor_id,
         "clinic_id": clinic_id,
         "appointment_datetime": _normalize_dt(appointment_datetime),
-        "status": "confirmed",
+        "status": status,
         "appointment_type": appointment_type,
         "notes": notes,
     }
@@ -219,6 +220,7 @@ def book_admin_appointment(
     doctor_id: str,
     appointment_date: date,
     appointment_time: time,
+    status: Literal["pending", "confirmed"] = "confirmed",
     notes: str | None = None,
     accept_waitlist: bool = False,
     allow_override: bool = False,
@@ -260,6 +262,7 @@ def book_admin_appointment(
             clinic_id=clinic_id,
             appointment_datetime=requested_slot,
             appointment_type="MAIN",
+            status=status,
             notes=notes,
         )
 
@@ -306,6 +309,7 @@ def book_admin_appointment(
                     clinic_id=clinic_id,
                     appointment_datetime=next_slot,
                     appointment_type="WAITLIST",
+                    status=status,
                     notes=waitlist_notes,
                 )
 
@@ -344,6 +348,7 @@ def book_admin_appointment(
             clinic_id=clinic_id,
             appointment_datetime=requested_slot,
             appointment_type="OVERRIDE",
+            status=status,
             notes=override_notes,
         )
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .appointments import appointments_bp
 from .admin import admin_bp
 from .auth import auth_bp
 from .daily_slots import slots_bp
+from .scheduling_appointments import scheduling_appointments_bp
 from .auth import auth_bp
 
 
@@ -19,4 +20,8 @@ def register_routes(app):
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(appointments_bp, url_prefix='/api/appointments')
     app.register_blueprint(admin_bp, url_prefix='/api/admin')
+    app.register_blueprint(
+        scheduling_appointments_bp,
+        url_prefix='/api/scheduling/appointments',
+    )
     app.register_blueprint(slots_bp)

--- a/backend/app/routes/scheduling_appointments.py
+++ b/backend/app/routes/scheduling_appointments.py
@@ -9,13 +9,17 @@ Endpoints:
 - PATCH /api/scheduling/appointments/<appointment_id>/cancel
 """
 
+from datetime import datetime
+
 from flask import Blueprint, request, jsonify, current_app
 from supabase import create_client, Client
 from app.middleware.auth_middleware import requires_auth
+from app.repositories.slot_bookings import book_admin_appointment, try_reserve_slot
 
 scheduling_appointments_bp = Blueprint("scheduling_appointments", __name__)
 
 VALID_STATUSES = {"pending", "confirmed", "cancelled", "completed"}
+CREATABLE_STATUSES = {"pending", "confirmed"}
 
 
 def _get_supabase_client() -> Client:
@@ -47,6 +51,47 @@ def _validate_json_request():
     return data
 
 
+def _parse_appointment_datetime(raw_value):
+    if raw_value is None or (isinstance(raw_value, str) and not raw_value.strip()):
+        return None
+
+    if not isinstance(raw_value, str):
+        raise ValueError("appointment_datetime must be a string")
+
+    normalized = raw_value.strip().replace("Z", "+00:00")
+    appointment_dt = datetime.fromisoformat(normalized)
+    if appointment_dt.second != 0 or appointment_dt.microsecond != 0:
+        raise ValueError("appointment_datetime must not include seconds or microseconds")
+    if appointment_dt.tzinfo is not None:
+        appointment_dt = appointment_dt.replace(tzinfo=None)
+
+    return appointment_dt
+
+
+def _get_appointment_by_id(supabase: Client, appointment_id):
+    response = (
+        supabase.table("appointments")
+        .select("*")
+        .eq("id", appointment_id)
+        .execute()
+    )
+    if not response.data:
+        return None
+    return response.data[0]
+
+
+def _get_doctor_clinic_id(supabase: Client, doctor_id):
+    response = (
+        supabase.table("doctors")
+        .select("clinic_id")
+        .eq("id", doctor_id)
+        .execute()
+    )
+    if not response.data:
+        return None
+    return response.data[0].get("clinic_id")
+
+
 @scheduling_appointments_bp.route("/", methods=["POST"])
 @requires_auth
 def create_appointment():
@@ -56,7 +101,7 @@ def create_appointment():
 
     data = validation_result
 
-    required_fields = ["patient_id", "doctor_id", "clinic_id", "appointment_datetime"]
+    required_fields = ["patient_id", "doctor_id", "appointment_datetime"]
     missing_fields = [
         field for field in required_fields
         if data.get(field) is None or (
@@ -71,37 +116,55 @@ def create_appointment():
             "errors": missing_fields
         }), 400
 
-    status = data.get("status", "pending")
-    if status not in VALID_STATUSES:
+    status = str(data.get("status", "pending")).strip().lower()
+    if status not in CREATABLE_STATUSES:
         return jsonify({
             "success": False,
-            "message": f"Invalid status. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            "message": (
+                "Invalid status for appointment creation. "
+                f"Must be one of: {', '.join(sorted(CREATABLE_STATUSES))}"
+            )
         }), 400
 
-    appointment_data = {
-        "patient_id": data["patient_id"].strip() if isinstance(data["patient_id"], str) else data["patient_id"],
-        "doctor_id": data["doctor_id"].strip() if isinstance(data["doctor_id"], str) else data["doctor_id"],
-        "clinic_id": data["clinic_id"].strip() if isinstance(data["clinic_id"], str) else data["clinic_id"],
-        "appointment_datetime": data["appointment_datetime"].strip()
-        if isinstance(data["appointment_datetime"], str) else data["appointment_datetime"],
-        "status": status,
-    }
-
     try:
-        supabase = _get_supabase_client()
-        response = supabase.table("appointments").insert(appointment_data).execute()
-
-        return jsonify({
-            "success": True,
-            "message": "Appointment created successfully",
-            "data": response.data
-        }), 201
-
-    except Exception as e:
+        appointment_dt = _parse_appointment_datetime(data["appointment_datetime"])
+    except ValueError:
         return jsonify({
             "success": False,
-            "message": str(e)
-        }), 500
+            "message": "Invalid appointment_datetime; use ISO-8601 format"
+        }), 400
+
+    patient_id = (
+        data["patient_id"].strip()
+        if isinstance(data["patient_id"], str)
+        else data["patient_id"]
+    )
+    doctor_id = (
+        data["doctor_id"].strip()
+        if isinstance(data["doctor_id"], str)
+        else data["doctor_id"]
+    )
+
+    result, err = book_admin_appointment(
+        patient_id=patient_id,
+        doctor_id=doctor_id,
+        appointment_date=appointment_dt.date(),
+        appointment_time=appointment_dt.time(),
+        status=status,
+        notes=data.get("notes"),
+        accept_waitlist=bool(data.get("accept_waitlist", False)),
+        allow_override=bool(data.get("allow_override", False)),
+    )
+
+    if err is not None:
+        body, status_code = err
+        return jsonify({"success": False, **body}), status_code
+
+    return jsonify({
+        "success": True,
+        "message": "Appointment created successfully",
+        "data": result,
+    }), 201
 
 
 @scheduling_appointments_bp.route("/doctor/<doctor_id>", methods=["GET"])
@@ -160,51 +223,108 @@ def update_appointment(appointment_id):
     validation_result = _validate_json_request()
     if not isinstance(validation_result, dict):
         return validation_result
-
     data = validation_result
-    update_data = {}
-
-    if "doctor_id" in data:
-        update_data["doctor_id"] = data["doctor_id"].strip() if isinstance(data["doctor_id"], str) else data["doctor_id"]
-
-    if "clinic_id" in data:
-        update_data["clinic_id"] = data["clinic_id"].strip() if isinstance(data["clinic_id"], str) else data["clinic_id"]
-
-    if "appointment_datetime" in data:
-        update_data["appointment_datetime"] = (
-            data["appointment_datetime"].strip()
-            if isinstance(data["appointment_datetime"], str)
-            else data["appointment_datetime"]
-        )
-
-    if "status" in data:
-        if data["status"] not in VALID_STATUSES:
-            return jsonify({
-                "success": False,
-                "message": f"Invalid status. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
-            }), 400
-        update_data["status"] = data["status"]
-
-    if not update_data:
-        return jsonify({
-            "success": False,
-            "message": "No valid fields were provided for update"
-        }), 400
 
     try:
         supabase = _get_supabase_client()
+        existing_appointment = _get_appointment_by_id(supabase, appointment_id)
+        if not existing_appointment:
+            return jsonify({
+                "success": False,
+                "message": "Appointment not found"
+            }), 404
+
+        current_doctor_id = existing_appointment.get("doctor_id")
+        current_datetime_raw = existing_appointment.get("appointment_datetime")
+        current_datetime = _parse_appointment_datetime(current_datetime_raw)
+
+        target_doctor_id = current_doctor_id
+        if "doctor_id" in data:
+            target_doctor_id = (
+                data["doctor_id"].strip()
+                if isinstance(data["doctor_id"], str)
+                else data["doctor_id"]
+            )
+            if not target_doctor_id:
+                return jsonify({
+                    "success": False,
+                    "message": "doctor_id cannot be empty"
+                }), 400
+
+        target_datetime = current_datetime
+        if "appointment_datetime" in data:
+            try:
+                target_datetime = _parse_appointment_datetime(data["appointment_datetime"])
+            except ValueError:
+                return jsonify({
+                    "success": False,
+                    "message": "Invalid appointment_datetime; use ISO-8601 format without seconds"
+                }), 400
+            if target_datetime is None:
+                return jsonify({
+                    "success": False,
+                    "message": "appointment_datetime cannot be empty"
+                }), 400
+
+        update_data = {}
+        if "status" in data:
+            status = str(data["status"]).strip().lower()
+            if status not in VALID_STATUSES:
+                return jsonify({
+                    "success": False,
+                    "message": f"Invalid status. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+                }), 400
+            update_data["status"] = status
+
+        scheduling_changed = (
+            target_doctor_id != current_doctor_id
+            or target_datetime != current_datetime
+        )
+
+        if scheduling_changed:
+            err = try_reserve_slot(
+                target_doctor_id,
+                target_datetime.date(),
+                target_datetime.time(),
+            )
+            if err is not None:
+                body, status_code = err
+                return jsonify({"success": False, **body}), status_code
+
+            clinic_id = _get_doctor_clinic_id(supabase, target_doctor_id)
+            if not clinic_id:
+                return jsonify({
+                    "success": False,
+                    "message": "Could not determine clinic for selected doctor."
+                }), 400
+
+            update_data["doctor_id"] = target_doctor_id
+            update_data["appointment_datetime"] = target_datetime.isoformat()
+            update_data["clinic_id"] = clinic_id
+        else:
+            if "doctor_id" in data:
+                update_data["doctor_id"] = target_doctor_id
+            if "appointment_datetime" in data:
+                update_data["appointment_datetime"] = target_datetime.isoformat()
+            if "clinic_id" in data:
+                update_data["clinic_id"] = (
+                    data["clinic_id"].strip()
+                    if isinstance(data["clinic_id"], str)
+                    else data["clinic_id"]
+                )
+
+        if not update_data:
+            return jsonify({
+                "success": False,
+                "message": "No valid fields were provided for update"
+            }), 400
+
         response = (
             supabase.table("appointments")
             .update(update_data)
             .eq("id", appointment_id)
             .execute()
         )
-
-        if not response.data:
-            return jsonify({
-                "success": False,
-                "message": "Appointment not found"
-            }), 404
 
         return jsonify({
             "success": True,

--- a/backend/tests/test_scheduling_appointments_source_of_truth.py
+++ b/backend/tests/test_scheduling_appointments_source_of_truth.py
@@ -1,0 +1,267 @@
+from datetime import date
+
+import pytest
+
+from app.repositories import availability
+from app.repositories import slot_bookings
+from app.routes import scheduling_appointments as scheduling_routes
+
+
+DOCTOR = "dr-1"
+DAY = date(2026, 3, 9)
+
+
+@pytest.fixture
+def fake_supabase(monkeypatch):
+    fake_appointments = []
+    fake_doctors = {
+        DOCTOR: {"id": DOCTOR, "clinic_id": "fake-clinic-id"},
+        "dr-2": {"id": "dr-2", "clinic_id": "clinic-2"},
+    }
+
+    def fake_supabase_request(method, path, *, query=None, json_body=None):
+        query = query or {}
+
+        if method == "GET" and path == "/rest/v1/doctors":
+            if query.get("select") == "clinic_id":
+                return 200, [{"clinic_id": "fake-clinic-id"}], None
+
+        if method == "GET" and path == "/rest/v1/appointments":
+            doctor_id = query.get("doctor_id", "").replace("eq.", "")
+            appointment_datetime = query.get("appointment_datetime", "").replace("eq.", "")
+            status_filter = query.get("status", "")
+
+            results = [
+                appt for appt in fake_appointments
+                if appt["doctor_id"] == doctor_id
+            ]
+
+            if appointment_datetime:
+                results = [
+                    appt for appt in results
+                    if appt["appointment_datetime"] == appointment_datetime
+                ]
+
+            if status_filter == "in.(pending,confirmed)":
+                results = [
+                    appt for appt in results
+                    if appt.get("status") in ("pending", "confirmed")
+                ]
+
+            return 200, results, None
+
+        if method == "POST" and path == "/rest/v1/appointments":
+            new_appointment = dict(json_body)
+            new_appointment["id"] = len(fake_appointments) + 1
+            fake_appointments.append(new_appointment)
+            return 201, [new_appointment], None
+
+        return 404, None, f"Unhandled fake request: {method} {path}"
+
+    class FakeResponse:
+        def __init__(self, data):
+            self.data = data
+
+    class FakeTableQuery:
+        def __init__(self, table_name):
+            self.table_name = table_name
+            self.filters = {}
+            self.update_payload = None
+
+        def select(self, *_args, **_kwargs):
+            return self
+
+        def eq(self, field, value):
+            self.filters[field] = value
+            return self
+
+        def order(self, *_args, **_kwargs):
+            return self
+
+        def update(self, payload):
+            self.update_payload = payload
+            return self
+
+        def execute(self):
+            if self.table_name == "appointments":
+                matches = [
+                    appt for appt in fake_appointments
+                    if all(appt.get(field) == value for field, value in self.filters.items())
+                ]
+                if self.update_payload is None:
+                    return FakeResponse([dict(appt) for appt in matches])
+
+                updated = []
+                for appt in matches:
+                    appt.update(self.update_payload)
+                    updated.append(dict(appt))
+                return FakeResponse(updated)
+
+            if self.table_name == "doctors":
+                doctor_id = self.filters.get("id")
+                doctor = fake_doctors.get(doctor_id)
+                return FakeResponse([dict(doctor)] if doctor else [])
+
+            return FakeResponse([])
+
+    class FakeSupabaseClient:
+        def table(self, table_name):
+            return FakeTableQuery(table_name)
+
+    monkeypatch.setattr(availability, "_supabase_request", fake_supabase_request)
+    monkeypatch.setattr(slot_bookings, "_supabase_request", fake_supabase_request)
+    monkeypatch.setattr(
+        scheduling_routes,
+        "_get_supabase_client",
+        lambda: FakeSupabaseClient(),
+    )
+
+    return fake_appointments
+
+
+def test_create_scheduling_appointment_uses_shared_booking_logic(
+    client,
+    auth_headers,
+    fake_supabase,
+):
+    response = client.post(
+        "/api/scheduling/appointments/",
+        json={
+            "patient_id": "patient-1",
+            "doctor_id": DOCTOR,
+            "appointment_datetime": f"{DAY.isoformat()}T09:00:00",
+            "status": "pending",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["booking_type"] == "MAIN"
+    assert payload["data"]["appointment"]["status"] == "pending"
+    assert payload["data"]["assigned_datetime"] == f"{DAY.isoformat()}T09:00:00"
+    assert len(fake_supabase) == 1
+
+
+def test_scheduling_create_endpoint_and_available_slots_share_capacity_rules(
+    client,
+    auth_headers,
+    fake_supabase,
+):
+    booking_payload = {
+        "doctor_id": DOCTOR,
+        "appointment_datetime": f"{DAY.isoformat()}T09:00:00",
+    }
+
+    for patient_id in ("patient-1", "patient-2"):
+        response = client.post(
+            "/api/scheduling/appointments/",
+            json={**booking_payload, "patient_id": patient_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+
+    slots_response = client.get(
+        f"/api/doctors/{DOCTOR}/available-slots",
+        query_string={"date": DAY.isoformat()},
+        headers=auth_headers,
+    )
+
+    assert slots_response.status_code == 200
+    assert "09:00" not in slots_response.get_json()["slots"]
+
+    full_slot_response = client.post(
+        "/api/scheduling/appointments/",
+        json={**booking_payload, "patient_id": "patient-3"},
+        headers=auth_headers,
+    )
+
+    assert full_slot_response.status_code == 409
+    payload = full_slot_response.get_json()
+    assert payload["success"] is False
+    assert payload["error"] == "Unable to book appointment."
+    assert len(fake_supabase) == 2
+
+
+def test_update_scheduling_appointment_rejects_reschedule_into_full_slot(
+    client,
+    auth_headers,
+    fake_supabase,
+):
+    fake_supabase.extend(
+        [
+            {
+                "id": "appt-1",
+                "patient_id": "patient-1",
+                "doctor_id": DOCTOR,
+                "clinic_id": "fake-clinic-id",
+                "appointment_datetime": f"{DAY.isoformat()}T09:30:00",
+                "status": "confirmed",
+                "appointment_type": "MAIN",
+                "notes": None,
+            },
+            {
+                "id": "appt-2",
+                "patient_id": "patient-2",
+                "doctor_id": DOCTOR,
+                "clinic_id": "fake-clinic-id",
+                "appointment_datetime": f"{DAY.isoformat()}T09:00:00",
+                "status": "confirmed",
+                "appointment_type": "MAIN",
+                "notes": None,
+            },
+            {
+                "id": "appt-3",
+                "patient_id": "patient-3",
+                "doctor_id": DOCTOR,
+                "clinic_id": "fake-clinic-id",
+                "appointment_datetime": f"{DAY.isoformat()}T09:00:00",
+                "status": "pending",
+                "appointment_type": "MAIN",
+                "notes": None,
+            },
+        ]
+    )
+
+    response = client.put(
+        "/api/scheduling/appointments/appt-1",
+        json={"appointment_datetime": f"{DAY.isoformat()}T09:00:00"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["error"] == "This time slot is full"
+    assert fake_supabase[0]["appointment_datetime"] == f"{DAY.isoformat()}T09:30:00"
+
+
+def test_update_scheduling_appointment_rejects_seconds_in_datetime(
+    client,
+    auth_headers,
+    fake_supabase,
+):
+    fake_supabase.append(
+        {
+            "id": "appt-1",
+            "patient_id": "patient-1",
+            "doctor_id": DOCTOR,
+            "clinic_id": "fake-clinic-id",
+            "appointment_datetime": f"{DAY.isoformat()}T09:30:00",
+            "status": "confirmed",
+            "appointment_type": "MAIN",
+            "notes": None,
+        }
+    )
+
+    response = client.put(
+        "/api/scheduling/appointments/appt-1",
+        json={"appointment_datetime": f"{DAY.isoformat()}T10:00:30"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert "appointment_datetime" in payload["message"]


### PR DESCRIPTION
## Summary
- route scheduling appointment creation through the shared slot-booking validation and capacity logic
- give the scheduling `PUT` update flow the same source-of-truth slot validation behavior for rescheduling changes
- add focused regression tests to keep scheduling create/update behavior aligned with available-slots rules

## Test plan
- [x] `pytest backend/tests/test_scheduling_appointments_source_of_truth.py backend/tests/test_scheduling_decision_table.py backend/tests/test_scheduling_ep_bva.py`

