### PR TITLE
Fix Milestone 3: uncomment section-LTT include

### DIFF
--- a/docs/Milestone_3/documentation.adoc
+++ b/docs/Milestone_3/documentation.adoc
@@ -38,7 +38,7 @@ include::sections/section-3/section.adoc[]
 
 include::sections/section-4/section.adoc[]
 
-// include::sections/section-LTT/section.adoc[]
+include::sections/section-LTT/section.adoc[]
 
 include::sections/AI_Disclosure_Statement.adoc[]
 


### PR DESCRIPTION
The LTT section was commented out in Milestone 3's documentation.adoc, which hid all the testing content (Usability, Property-Based Testing, Fuzzing, and Types) from the submitted document. This PR removes the comment so that section is visible.